### PR TITLE
feat: expose edit_date in MessageInfo JSON output

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -2349,6 +2349,33 @@ mod tests {
     }
 
     #[test]
+    fn edit_date_zero_maps_to_none() {
+        let edit_date: i32 = 0;
+        let result: Option<String> = if edit_date == 0 {
+            None
+        } else {
+            Some(format_timestamp(edit_date))
+        };
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn edit_date_positive_maps_to_some_iso8601() {
+        let edit_date: i32 = 1_700_000_000;
+        let result: Option<String> = if edit_date == 0 {
+            None
+        } else {
+            Some(format_timestamp(edit_date))
+        };
+        assert!(result.is_some());
+        let date_str = result.unwrap();
+        // Should be a valid ISO 8601 / RFC 3339 string
+        assert!(date_str.contains('T'));
+        assert!(date_str.ends_with('Z'));
+        assert_eq!(date_str, "2023-11-14T22:13:20Z");
+    }
+
+    #[test]
     fn build_filename_marks_primary_for_multiple_files() {
         let primary = MessageFileRef {
             file_id: 1,

--- a/src/output.rs
+++ b/src/output.rs
@@ -910,6 +910,44 @@ mod tests {
     }
 
     #[test]
+    fn message_info_json_edit_date_none_is_omitted() {
+        let msg = MessageInfo {
+            id: 1,
+            chat_id: 123,
+            sender: "Alice".to_string(),
+            text: "Hello".to_string(),
+            date: "2024-01-01T00:00:00Z".to_string(),
+            is_outgoing: false,
+            edit_date: None,
+            content_type: None,
+            is_downloadable: false,
+            download_files: vec![],
+            content: None,
+        };
+        let json = serde_json::to_string(&msg).unwrap();
+        assert!(!json.contains("edit_date"));
+    }
+
+    #[test]
+    fn message_info_json_edit_date_some_is_included() {
+        let msg = MessageInfo {
+            id: 1,
+            chat_id: 123,
+            sender: "Alice".to_string(),
+            text: "Hello (edited)".to_string(),
+            date: "2024-01-01T00:00:00Z".to_string(),
+            is_outgoing: false,
+            edit_date: Some("2024-01-01T00:05:00Z".to_string()),
+            content_type: None,
+            is_downloadable: false,
+            download_files: vec![],
+            content: None,
+        };
+        let json = serde_json::to_string(&msg).unwrap();
+        assert!(json.contains("\"edit_date\":\"2024-01-01T00:05:00Z\""));
+    }
+
+    #[test]
     fn send_result_plain_text() {
         let result = SendResult {
             message_id: 12345,


### PR DESCRIPTION
Closes #1

## Changes
- **`src/output.rs`**: Added `edit_date: Option<String>` to `MessageInfo` — serializes as ISO 8601 when edited, omitted from JSON when `None`
- **`src/client.rs`**: Maps `msg.edit_date`: `0` → `None`, `>0` → `Some(ISO 8601 string)`