### PR TITLE
Add tg serve: long-lived TDLib server with transparent CLI routing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2179,6 +2179,7 @@ dependencies = [
  "colored",
  "comfy-table",
  "dirs",
+ "libc",
  "reqwest 0.12.28",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ terminal_size = "0.3"
 unicode-width = "0.2"
 chrono = "0.4"
 reqwest = { version = "0.12", features = ["json", "rustls-tls"] }
+libc = "0.2"
 
 [dev-dependencies]
 tempfile = "3"

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A modern CLI tool for interacting with Telegram, built in Rust using [TDLib](htt
 - **Search** — find contacts by name
 - **Download** — download media attachments from messages
 - **Mark read/unread** — manage read state of chats
+- **Long-lived server** — `tg serve` keeps a TDLib client warm so every other `tg <cmd>` skips cold start
 - **Bulk sync** — fetch new messages for multiple chats in a single session (machine use)
 - **JSON output** — pass `--json` to any command for machine-readable output
 
@@ -102,14 +103,49 @@ tg search "John"
 tg mark-read "John Doe"
 tg mark-unread --id 123456789
 
-# Bulk sync (machine use — reads JSON from stdin, outputs JSON to stdout)
-echo '{"123": 42, "-1001666847309": 89508544512}' | tg sync
-echo '{"123": 0}' | tg sync --reconcile-days 7 --limit 500
+# Run the long-lived server so other commands skip cold start
+tg serve
 ```
 
-### Bulk sync
+## Machine use
 
-`tg sync` fetches new messages for multiple chats in a single TDLib session, avoiding per-chat process startup overhead. It reads a JSON map of `{chat_id: last_message_id}` from stdin and outputs results keyed by chat ID.
+`tg serve` runs a long-lived background process that keeps one TDLib client warm and exposes it over a Unix socket. Every other `tg <cmd>` automatically routes through it when it's up — and falls back to in-process TDLib (today's behaviour) when it isn't. The server is a pure performance optimisation; nothing breaks without it.
+
+### Running the server
+
+```bash
+tg serve                                  # foreground
+podman exec -d tg tg serve                # backgrounded inside a container
+```
+
+The socket path is resolved in this order:
+
+1. `TG_SERVE_SOCKET=/explicit/path` — use that path verbatim.
+2. `TG_SERVE_SOCKET=` (set but empty) — disabled; clients always use in-process TDLib.
+3. `$XDG_RUNTIME_DIR/tg.sock` if `XDG_RUNTIME_DIR` is set.
+4. `$DATA_DIR/tg/serve.sock` (e.g. `~/Library/Application Support/tg/serve.sock` on macOS).
+
+The socket is created with `0600` permissions. Concurrent connections are accepted, but TDLib calls are serialised internally — slow commands (e.g. `download`) block the channel until they complete.
+
+**Operational notes:**
+
+- `tg auth`, `tg auth bot`, and `tg auth status` cannot run while `tg serve` is active. Stop the server first, run auth, then start the server again.
+- Bot sends (`tg send --as <bot>`) use the HTTP API and bypass the socket — they work whether the server is up or not.
+- Restarting the server gives you a cold TDLib but the on-disk session survives, so re-auth is not needed.
+
+### Wire protocol (for non-`tg`-CLI clients)
+
+Newline-delimited JSON on the Unix socket. One request per line, one response per line, in arrival order.
+
+Request: `{"id": "<opaque>", "cmd": "<command>", "args": { ... }}`
+Response (success): `{"id": "<echoed>", "ok": true, "result": <value>}`
+Response (failure): `{"id": "<echoed>", "ok": false, "error": "<message>"}`
+
+`cmd` is one of: `whoami`, `chats`, `groups`, `unread`, `search`, `messages`, `send`, `download`, `mark_read`, `mark_unread`, `sync`. `args` field names are snake_case and match the corresponding CLI flags. The `result` shape matches each command's `--json` output today.
+
+### One-shot bulk sync
+
+`tg sync` is a one-shot variant of the server's `sync` command for callers that don't want to maintain a long-lived child. It reads a JSON map of `{chat_id: last_message_id}` from stdin and outputs results keyed by chat ID. Works whether or not `tg serve` is up — when the server is running, the request goes through the socket; otherwise it cold-starts TDLib.
 
 ```bash
 # Stdin: map of chat ID (string) → last seen message ID (integer)

--- a/docs/superpowers/specs/2026-05-22-serve-design.md
+++ b/docs/superpowers/specs/2026-05-22-serve-design.md
@@ -1,0 +1,266 @@
+# Long-Running Server Command (`tg serve`)
+
+## Problem
+
+Mycelium (and any other machine consumer) currently invokes `tg` one subcommand per call. Every call pays the full TDLib cold-start cost: client construction, FFI thread spawn, server handshake, chat-list bootstrap. For interactive workloads — alternating `whoami`, `chats`, `messages`, `send`, `download`, `search`, `mark-read`, `mark-unread` — this dominates wall-clock time and produces a noisy thrash of init/teardown work.
+
+`tg sync` solved this for bulk message ingestion (one process, many chats), but only for that one verb. Everything else still pays cold start per call.
+
+## Solution
+
+A new `tg serve` subcommand: a long-running JSON-on-stdio service. One TDLib client is initialised at startup and reused for every request. The caller (typically `podman exec -i tg tg serve`) sends newline-delimited JSON requests on stdin and reads newline-delimited JSON responses on stdout. Requests are handled serially, in arrival order. Errors are reported in-band and never tear down the session. The session ends cleanly on stdin EOF or SIGTERM.
+
+This is not a REPL for humans — there is no prompt, no readline, no plain-text output. It is a single-client JSON-RPC channel that piggybacks on stdio because that is the cheapest possible IPC inside a container.
+
+## Wire Protocol
+
+Newline-delimited JSON in both directions. Stdout is exclusively JSON; all human-readable output (TDLib logs, progress, warnings) is routed to stderr.
+
+### Request
+
+```json
+{"id": "<opaque>", "cmd": "<command>", "args": { ... }}
+```
+
+- `id` (string, required): caller-chosen opaque correlation token. Echoed back on the matching response. The server does not interpret it.
+- `cmd` (string, required): the command name (see [Command Set](#command-set)).
+- `args` (object, optional): command-specific arguments. May be omitted when the command takes no arguments. Field names are snake_case and match the corresponding clap flag names (e.g. `since_utc`, `output_dir`, `oldest_first`).
+
+### Response
+
+Exactly one response is emitted for every request, in request-arrival order.
+
+Success:
+
+```json
+{"id": "<echoed>", "ok": true, "result": <value>}
+```
+
+Failure:
+
+```json
+{"id": "<echoed>", "ok": false, "error": "<message>"}
+```
+
+- `result` shape matches the existing `--json` output of the corresponding subcommand (`MessageInfo`, `ChatInfo`, `SendResult`, `DownloadReport`, etc.). When today's CLI prints an array (e.g. `tg chats --json` prints `[ChatInfo, ...]`), `result` is that array. When it prints a single object, `result` is that object. When the CLI emits no payload (e.g. `tg mark-read`), `result` is `null`.
+- `error` is a single human-readable string sourced from `TgError::to_string()`. No nested error envelope, no machine-readable error code in v1.
+
+### Framing rules
+
+- Each request and each response is a single line of UTF-8 JSON terminated by `\n`. No pretty-printing on the wire — `serde_json::to_string` (not `to_string_pretty`).
+- A request that fails to parse as JSON, or whose top-level shape is invalid (missing `id`, missing `cmd`, etc.), produces an error response. The server attempts to extract `id` if present; if not, the response uses `"id": null`.
+- A request with an unrecognised `cmd` produces `{"id": ..., "ok": false, "error": "unknown command: <cmd>"}`.
+- Empty lines on stdin are ignored.
+- Stdout is line-buffered (or explicitly flushed after each response) so the caller sees responses as they happen.
+
+### Reserved for future use
+
+The protocol reserves the shape `{"event": "<name>", "data": <value>}` (no `id`, no `ok`) for unsolicited server-to-client messages — TDLib update notifications, for example. The v1 server never emits these, but clients SHOULD ignore unrecognised top-level shapes rather than treating them as errors, so that future additions are non-breaking.
+
+## CLI Interface
+
+```
+tg serve
+```
+
+No flags in v1. No `--json` (output is always JSON). The global `--json` flag is ignored if passed — the protocol is not negotiable.
+
+Stdin: newline-delimited JSON requests.
+Stdout: newline-delimited JSON responses.
+Stderr: TDLib logs, parse-error notes, panic backtraces, anything humans might read.
+
+## Command Set
+
+Every existing read/write subcommand is reachable via `serve`. Mapping:
+
+| `cmd`         | Args struct           | Result type                 | Notes                                              |
+| ------------- | --------------------- | --------------------------- | -------------------------------------------------- |
+| `whoami`      | _none_                | `UserInfo`                  |                                                    |
+| `chats`       | `ChatsRequest`        | `Vec<ChatInfo>`             | `{ "limit": 50 }` default                          |
+| `groups`      | `GroupsRequest`       | `Vec<ChatInfo>`             |                                                    |
+| `unread`      | `UnreadRequest`       | `Vec<ChatInfo>`             |                                                    |
+| `search`      | `SearchRequest`       | `Vec<ContactInfo>`          | `{ "query": "..." }`                               |
+| `messages`    | `MessagesRequest`     | `Vec<MessageInfo>`          | accepts either `name` or `chat`; mirrors CLI rules |
+| `send`        | `SendRequest`         | `SendResult`                | `--as` (bot send) is not supported by `serve` v1   |
+| `download`    | `DownloadRequest`     | `DownloadReport`            | `output_dir` resolved inside the container         |
+| `mark_read`   | `MarkReadRequest`     | `null`                      |                                                    |
+| `mark_unread` | `MarkUnreadRequest`   | `null`                      |                                                    |
+| `sync`        | `SyncRequest`         | `HashMap<String, SyncResult>` | HWM map moves into `args.hwm`; see [Sync](#sync) |
+
+Notably **excluded**: `auth`, `auth bot`, `auth status`. These are interactive and/or modify on-disk credentials; the operator must stop `tg serve` before running them. Attempting `cmd: "auth"` returns `{"ok": false, "error": "auth is not available over serve; run \`tg auth\` directly"}`.
+
+Bot sends (`--as`) are excluded from v1 because they use the HTTP API rather than the shared TDLib client; adding them is a clean follow-up.
+
+### Sync
+
+`sync` is the one command whose CLI form takes structured stdin. In `serve` mode that input moves into the request envelope:
+
+```json
+{"id": "s1", "cmd": "sync", "args": {
+  "hwm": {"-1001666847309": 89508544512, "123456789": 0},
+  "limit": 1000
+}}
+```
+
+Today's `sync` writes per-chat results to stdout as a single pretty-printed JSON object after the run completes. In `serve`, the same map is the `result`. Progress lines that today go to stdout move to stderr (none exist today beyond the final dump, so this is mostly a no-op). The `--reconcile-days` flag becomes `args.reconcile_days: <u32 | null>`.
+
+## Architecture
+
+### New module: `src/commands/serve.rs`
+
+Owns the request/response loop:
+
+```rust
+pub async fn run(client: &mut TdLibClient) -> Result<()>;
+```
+
+It:
+
+1. Calls `client.start().await?` once at startup.
+2. Spawns a stdin reader (either a blocking thread feeding a `tokio::sync::mpsc` channel, or `tokio::io::BufReader<Stdin>::lines()`).
+3. Reads lines one at a time. For each line:
+   a. Parses into `Request` (`{id, cmd, args}` with `serde_json::Value` for `args`).
+   b. Dispatches to a per-command handler.
+   c. Writes the response line to stdout and flushes.
+4. On stdin EOF or SIGTERM: breaks the loop and returns. `main.rs` always calls `client.shutdown().await` afterwards.
+
+### Handler factoring
+
+Today, `main.rs::run_command` couples three things per command: clap-arg extraction, target/recipient resolution, and the actual TDLib call. `serve` needs the second and third parts without the first.
+
+Refactor each `commands/<name>.rs` to expose a function that takes a typed `<Name>Request` struct (or primitive args, where the existing handler already does) and returns a `Result<<ResultType>>`. Both code paths call that function:
+
+```
+clap args  ──► from_cli ──►  ChatsRequest ──┐
+                                            ├──► chats::handle(&client, req) ──► Vec<ChatInfo>
+serve args ──► serde_json::from_value ──────┘
+```
+
+Where the existing handler already takes primitive args (e.g. `messages::get_messages(client, target, limit, since_utc, oldest_first)`), the new `handle` function is a thin wrapper that constructs those primitives from the request struct. No semantic changes to the inner handlers.
+
+The `<Name>Request` structs live in a new `src/commands/request.rs` (or per-command, beside each handler — to be decided in the plan). They derive `Deserialize`, with `#[serde(default)]` on optional fields so omitted keys behave like the CLI defaults (e.g. `limit: 50`).
+
+The clap `*Args` structs in `cli.rs` are unchanged. Conversions live in `main.rs` (or beside each handler) and are mechanical: `ChatsArgs { limit } → ChatsRequest { limit }`.
+
+### Dispatcher
+
+A single `match cmd.as_str()` in `serve.rs` routes to handlers:
+
+```rust
+let result: Result<serde_json::Value> = match req.cmd.as_str() {
+    "whoami"      => to_value(whoami::handle(client).await?),
+    "chats"       => to_value(chats::handle(client, from_value(req.args)?).await?),
+    "messages"    => to_value(messages::handle(client, from_value(req.args)?).await?),
+    // ...
+    "auth" | "auth_bot" | "auth_status" => Err(TgError::Other(
+        "auth is not available over serve; run `tg auth` directly".into())),
+    other => Err(TgError::Other(format!("unknown command: {other}"))),
+};
+```
+
+Where `to_value` uses `serde_json::to_value` and `()` → `Value::Null`.
+
+### Concurrency
+
+Strictly serial. The dispatcher awaits each handler to completion before reading the next line. This matches the current `main.rs::run_command` model exactly — no new concurrency invariants for TDLib to worry about. A slow `download` blocks subsequent requests; mycelium is expected to tear down the session and respawn if a command hangs (per the brief).
+
+### Stdout discipline
+
+Two rules:
+
+1. Every byte written to stdout is part of a JSON response line, ending in `\n`. Nothing else.
+2. All other output — handler-internal `eprintln!`s, panic messages, TDLib chatter — goes to stderr.
+
+To enforce rule 2, audit existing handlers for any `println!` / `print!` calls and either remove them or route them through `eprintln!`. A quick grep shows the suspects are:
+
+- `messages::run` prints an `eprintln!` already when filtering returns empty (fine).
+- `sync` currently does its final dump via `println!` from `main.rs` — that's the `main.rs` caller's responsibility, so handlers themselves are clean.
+
+If any future handler prints to stdout it will silently corrupt the channel. A simple `#![deny(clippy::print_stdout)]` lint on `commands/` would catch this; whether to add it is left to the plan.
+
+### Lifecycle
+
+Startup:
+
+1. `main.rs` loads credentials and constructs `TdLibClient` (same as today).
+2. Routes `Command::Serve` to `serve::run(&mut client)`.
+3. `serve::run` calls `client.start().await?` and enters the loop.
+
+Shutdown triggers:
+
+- **Stdin EOF** (caller closed the pipe): break the loop cleanly.
+- **SIGTERM / SIGINT**: install a `tokio::signal` handler that flips an `AtomicBool`; the loop checks it between requests. In-flight request is allowed to complete (per "tear down + respawn for hangs" — graceful shutdown does not pre-empt a long `download`). For SIGKILL or container kill, the process dies and TDLib state stays consistent on disk because TDLib commits incrementally.
+
+In all clean exits, `main.rs` calls `client.shutdown().await` (the existing path). Exit code `0`.
+
+### Container assumption
+
+`podman exec -i tg tg serve` runs a new `tg serve` instance per `exec` call inside the running container. The expected usage is: mycelium holds **one** long-lived `serve` child (one `podman exec -i`), writes many requests over its lifetime, and closes stdin when shutting down. If mycelium restarts, it gets a cold TDLib but TDLib's on-disk session survives — auth is preserved. This document does not change anything about the container itself; the existing `Containerfile` already builds `tg`, and `tg serve` is just another subcommand.
+
+## Errors
+
+- Parse error on a request line → `{"id": <if extractable, else null>, "ok": false, "error": "invalid request: <serde message>"}`. Loop continues.
+- Unknown `cmd` → `{"id": ..., "ok": false, "error": "unknown command: <cmd>"}`. Loop continues.
+- Handler returns `Err(TgError::...)` → `{"id": ..., "ok": false, "error": "<TgError to_string>"}`. Loop continues.
+- Catastrophic TDLib failure (e.g. authentication revoked mid-session): handlers will return `Err`; subsequent requests will likely also fail. The server does not attempt to re-initialise TDLib. The operator decides whether to kill and restart.
+
+## Out of Scope (v1)
+
+- Authentication commands (`auth`, `auth bot`, `auth status`).
+- Bot sends (`send --as <bot>`).
+- Streaming responses (multiple frames per request id). All responses are single frames.
+- Per-request cancellation or timeout. Caller tears down + respawns.
+- Multi-client concurrency (multiple parallel `podman exec` sessions). Single client only; document it in the README.
+- Update notifications (TDLib `updateNewMessage` etc.). Protocol leaves room for `{"event": ...}` frames but the v1 server never emits any.
+- Machine-readable error codes / typed error envelopes. Strings only in v1.
+
+## Testing
+
+### Unit (in `src/commands/serve.rs`)
+
+Dispatcher tests using a `MockClient` (already exists in `src/client.rs`'s `mock` module):
+
+- Request with valid `cmd: "whoami"` returns `{"ok": true, "result": {...}}` with `id` echoed.
+- Request with unknown `cmd` returns `{"ok": false, "error": "unknown command: ..."}` and the loop continues to process the next request.
+- Request with malformed JSON returns `{"ok": false, "error": "invalid request: ..."}` with `id: null`.
+- Request that triggers a handler error returns `{"ok": false}` with the error message verbatim.
+- Multiple requests are processed in arrival order; response `id`s match input `id`s in order.
+
+These tests drive `serve::dispatch_one(client, line) -> String` (a pure function) directly, no real stdio.
+
+### Integration (in `tests/`)
+
+A new `tests/serve_integration.rs` (`#[cfg(feature = "integration")]` or behind a `--ignored` marker — to be decided in the plan, mirroring whatever convention `tests/` already uses):
+
+1. Spawn `tg serve` as a child process via `std::process::Command` with piped stdin/stdout.
+2. The test uses the mock-backed code paths where possible; if a real TDLib is required, gate the test behind an env var (`TG_SERVE_INTEGRATION=1`) so CI doesn't try to talk to Telegram.
+3. Write two requests (`whoami`, `chats --limit 1`) to stdin.
+4. Read two response lines from stdout.
+5. Assert: both responses parse as JSON, `id` values match request order, `ok: true`, expected `result` shape.
+6. Close stdin. Wait for process exit. Assert exit code 0.
+
+If standing up a real TDLib in CI is impractical, the integration test reuses the existing test harness pattern (whatever `tests/` already does for end-to-end coverage) and the round-trip assertions stay; the inner data is mocked.
+
+## README updates
+
+The existing README has a "Bulk sync" section that documents `tg sync` as the machine-use entry point. Replace it with a broader **"Machine use"** section that:
+
+1. Leads with `tg serve` as the preferred entry point for any long-running caller: explains the wire protocol, the request/response shape, lifecycle, error semantics, and the single-client constraint.
+2. Retains `tg sync` as a one-shot variant for callers that only need bulk message ingestion and don't want to maintain a long-lived child.
+3. Documents the operational constraint that `tg auth` must be run with the `serve` session stopped, since both want exclusive access to TDLib's on-disk database.
+4. Shows the `podman exec -i tg tg serve` invocation pattern with a sample request/response exchange.
+
+The existing "Bulk sync" example (`echo '{"123": 42}' | tg sync`) stays, but moves under a "One-shot bulk sync" subheading.
+
+## File touch list
+
+- `src/cli.rs` — add `Command::Serve` variant (no args).
+- `src/main.rs` — route `Command::Serve` to `serve::run`; ensure clean shutdown path still runs.
+- `src/commands/mod.rs` — export new `serve` module.
+- `src/commands/serve.rs` — new. Request/response types, dispatcher, loop, signal handling.
+- `src/commands/request.rs` (or per-command request structs) — new. `Deserialize`-derived request structs and `From<*Args>` impls.
+- `src/commands/{chats,groups,unread,messages,search,send,download,mark_read,mark_unread,sync,whoami}.rs` — add or expose a `handle(client, req) -> Result<...>` function for each. Existing internals untouched.
+- `tests/serve_integration.rs` — new.
+- `README.md` — rewrite "Bulk sync" section as "Machine use".
+
+No changes to `auth.rs`, `bot_api.rs`, `client.rs`, `output.rs`, `credentials.rs`, `resolve.rs`, `error.rs`.

--- a/docs/superpowers/specs/2026-05-22-serve-design.md
+++ b/docs/superpowers/specs/2026-05-22-serve-design.md
@@ -2,19 +2,19 @@
 
 ## Problem
 
-Mycelium (and any other machine consumer) currently invokes `tg` one subcommand per call. Every call pays the full TDLib cold-start cost: client construction, FFI thread spawn, server handshake, chat-list bootstrap. For interactive workloads — alternating `whoami`, `chats`, `messages`, `send`, `download`, `search`, `mark-read`, `mark-unread` — this dominates wall-clock time and produces a noisy thrash of init/teardown work.
+Every `tg <cmd>` invocation pays the full TDLib cold-start cost: client construction, FFI thread spawn, server handshake, chat-list bootstrap. For interactive workloads — alternating `whoami`, `chats`, `messages`, `send`, `download`, `search`, `mark-read`, `mark-unread` — this dominates wall-clock time.
 
-`tg sync` solved this for bulk message ingestion (one process, many chats), but only for that one verb. Everything else still pays cold start per call.
+`tg sync` solved this for bulk message ingestion (one process, many chats) by jamming everything into one subcommand. That doesn't generalise: every other CLI invocation still cold-starts.
 
 ## Solution
 
-A new `tg serve` subcommand: a long-running JSON-on-stdio service. One TDLib client is initialised at startup and reused for every request. The caller (typically `podman exec -i tg tg serve`) sends newline-delimited JSON requests on stdin and reads newline-delimited JSON responses on stdout. Requests are handled serially, in arrival order. Errors are reported in-band and never tear down the session. The session ends cleanly on stdin EOF or SIGTERM.
+A new `tg serve` subcommand: a long-running background process whose sole job is to keep one TDLib client warm and expose it over a Unix domain socket. Every other `tg <cmd>` automatically detects the socket and forwards its request to the server; the server processes it against the warm TDLib client and returns the result; the client renders that result the same way it would have if it had executed locally. The user-visible UX of `tg messages`, `tg chats`, etc. is identical — only faster.
 
-This is not a REPL for humans — there is no prompt, no readline, no plain-text output. It is a single-client JSON-RPC channel that piggybacks on stdio because that is the cheapest possible IPC inside a container.
+When the socket isn't present (no `tg serve` running, or it crashed), CLI commands fall back to today's in-process TDLib path. `tg serve` is a pure performance optimisation; nothing breaks without it.
 
 ## Wire Protocol
 
-Newline-delimited JSON in both directions. Stdout is exclusively JSON; all human-readable output (TDLib logs, progress, warnings) is routed to stderr.
+Newline-delimited JSON over a Unix socket. One connection may carry one request (typical for CLI clients) or many requests in arrival order (long-lived clients like mycelium). The framing is the same in both cases.
 
 ### Request
 
@@ -22,13 +22,13 @@ Newline-delimited JSON in both directions. Stdout is exclusively JSON; all human
 {"id": "<opaque>", "cmd": "<command>", "args": { ... }}
 ```
 
-- `id` (string, required): caller-chosen opaque correlation token. Echoed back on the matching response. The server does not interpret it.
+- `id` (string, required): caller-chosen correlation token. Echoed back on the matching response. CLI clients can use any value (e.g. `"1"`); pipelining clients pick unique values per in-flight request.
 - `cmd` (string, required): the command name (see [Command Set](#command-set)).
 - `args` (object, optional): command-specific arguments. May be omitted when the command takes no arguments. Field names are snake_case and match the corresponding clap flag names (e.g. `since_utc`, `output_dir`, `oldest_first`).
 
 ### Response
 
-Exactly one response is emitted for every request, in request-arrival order.
+Exactly one response per request, in arrival order on the connection.
 
 Success:
 
@@ -42,58 +42,122 @@ Failure:
 {"id": "<echoed>", "ok": false, "error": "<message>"}
 ```
 
-- `result` shape matches the existing `--json` output of the corresponding subcommand (`MessageInfo`, `ChatInfo`, `SendResult`, `DownloadReport`, etc.). When today's CLI prints an array (e.g. `tg chats --json` prints `[ChatInfo, ...]`), `result` is that array. When it prints a single object, `result` is that object. When the CLI emits no payload (e.g. `tg mark-read`), `result` is `null`.
-- `error` is a single human-readable string sourced from `TgError::to_string()`. No nested error envelope, no machine-readable error code in v1.
+- `result` shape matches the existing `--json` output of the corresponding subcommand (`MessageInfo`, `ChatInfo`, `SendResult`, `DownloadReport`, etc.). When today's CLI prints an array, `result` is that array. When it prints a single object, `result` is that object. When the CLI emits no payload (e.g. `tg mark-read`), `result` is `null`.
+- `error` is a single human-readable string sourced from `TgError::to_string()`. No nested envelope, no machine-readable error code in v1.
 
 ### Framing rules
 
 - Each request and each response is a single line of UTF-8 JSON terminated by `\n`. No pretty-printing on the wire — `serde_json::to_string` (not `to_string_pretty`).
-- A request that fails to parse as JSON, or whose top-level shape is invalid (missing `id`, missing `cmd`, etc.), produces an error response. The server attempts to extract `id` if present; if not, the response uses `"id": null`.
+- A request that fails to parse, or whose top-level shape is invalid, produces an error response. The server attempts to extract `id` if present; if not, the response uses `"id": null`.
 - A request with an unrecognised `cmd` produces `{"id": ..., "ok": false, "error": "unknown command: <cmd>"}`.
-- Empty lines on stdin are ignored.
-- Stdout is line-buffered (or explicitly flushed after each response) so the caller sees responses as they happen.
+- Empty lines are ignored.
+- Stdout/socket writes are flushed after each response.
 
 ### Reserved for future use
 
 The protocol reserves the shape `{"event": "<name>", "data": <value>}` (no `id`, no `ok`) for unsolicited server-to-client messages — TDLib update notifications, for example. The v1 server never emits these, but clients SHOULD ignore unrecognised top-level shapes rather than treating them as errors, so that future additions are non-breaking.
 
-## CLI Interface
+## Socket
+
+### Location
+
+Resolved at startup (server and client agree on the same rule):
+
+1. If `TG_SERVE_SOCKET` is set and non-empty: use that absolute path verbatim.
+2. Otherwise, if `XDG_RUNTIME_DIR` is set: `$XDG_RUNTIME_DIR/tg.sock`.
+3. Otherwise: `dirs::data_dir()/tg/serve.sock` (e.g. `~/Library/Application Support/tg/serve.sock` on macOS).
+
+The server creates parent directories as needed with permissions `0700`, and the socket itself with permissions `0600`. The socket is owned by the user running `tg serve`; no other user can connect.
+
+If `TG_SERVE_SOCKET` is set to the empty string (`TG_SERVE_SOCKET=`), CLI clients treat the server as disabled and always use in-process TDLib. The server itself refuses to start with an empty `TG_SERVE_SOCKET`.
+
+### Lifecycle
+
+**Startup:**
+
+1. Resolve socket path.
+2. Check if a socket file already exists at that path. If it does, attempt to connect to it briefly:
+   - If the connection succeeds: another `tg serve` is already running. Exit with code `1` and print `tg serve: already running at <path>` to stderr.
+   - If the connection is refused: the socket is stale (previous server died). `unlink()` it and proceed.
+3. Construct `TdLibClient`, call `client.start().await?`, wait for sync.
+4. `bind()` the socket, `listen()`.
+5. Print `tg serve: listening at <path>` to stderr (informational; stdout stays clean for symmetry with the rest of the tool).
+6. Accept connections in a loop.
+
+**Per-connection:**
+
+- Read NDJSON requests until EOF. For each request, take the TDLib mutex, dispatch the handler, release the mutex, write the response line, flush.
+
+**Shutdown:**
+
+- SIGTERM / SIGINT: stop accepting new connections, finish any in-flight requests, call `client.shutdown().await`, unlink the socket, exit `0`.
+- Existing connections may be dropped abruptly if shutdown signals arrive during their requests; clients reading those responses get an EOF on the socket and surface a connection error.
+
+### Concurrency
+
+The server accepts many connections concurrently but serialises TDLib calls through a single `tokio::sync::Mutex<TdLibClient>`. This matches TDLib's single-writer assumption and the current CLI semantics. A slow `download` blocks other requests until it completes; callers tear down + retry (or wait) — see [Out of Scope](#out-of-scope-v1).
+
+## Client-Side Routing
+
+Every existing subcommand (except `auth`) is augmented to try the socket first:
 
 ```
-tg serve
+parse clap args
+  ↓
+construct <Cmd>Request   (typed, serde-Deserialize)
+  ↓
+try connect to socket
+  ├─ success: send request, read response, render result, exit
+  └─ refused/missing:
+       fall back to today's in-process path
 ```
 
-No flags in v1. No `--json` (output is always JSON). The global `--json` flag is ignored if passed — the protocol is not negotiable.
+The decision is made once at the top of each subcommand handler in `main.rs`. The same `<Cmd>Request` struct used by the server is used to build the request envelope on the client; the server deserialises it and dispatches to the same handler function.
 
-Stdin: newline-delimited JSON requests.
-Stdout: newline-delimited JSON responses.
-Stderr: TDLib logs, parse-error notes, panic backtraces, anything humans might read.
+Result rendering happens on the client side. The client receives the response JSON, deserialises `result` into the appropriate typed struct (`Vec<ChatInfo>`, `MessageInfo`, `DownloadReport`, etc.), and feeds it to the existing `print_*` helpers — so the `--json` vs plain-text choice, table layout, terminal width detection, and ANSI colour decisions all stay where they are today.
+
+### Path resolution
+
+Commands that take filesystem paths must resolve them on the client side before sending, because the server may have a different CWD. Specifically:
+
+- `tg download --output-dir <path>`: the client canonicalises `<path>` to an absolute path (`std::env::current_dir().join(path)`) and sends the absolute form in `args.output_dir`. The server writes there.
+
+### Auth
+
+`tg auth`, `tg auth bot`, `tg auth status` all bypass the socket entirely. Before running their normal flow, they check whether `tg serve` is running (by attempting a connection); if so they fail with:
+
+```
+tg auth: cannot run while `tg serve` is active.
+Stop the serve process and retry.
+```
+
+Reason: TDLib needs exclusive write access to its on-disk database, and `tg auth` modifies credentials anyway — running it through the server would mean re-auth doesn't take effect until the server restarts.
+
+### Send `--as` (bot send)
+
+Bot sends use the HTTP API, not TDLib, so they don't benefit from the warm client. `tg send --as <bot>` ignores the socket and runs in-process today's way. The non-bot `tg send` does route through the socket.
 
 ## Command Set
 
-Every existing read/write subcommand is reachable via `serve`. Mapping:
+The server accepts every subcommand whose handler talks to TDLib:
 
-| `cmd`         | Args struct           | Result type                 | Notes                                              |
-| ------------- | --------------------- | --------------------------- | -------------------------------------------------- |
-| `whoami`      | _none_                | `UserInfo`                  |                                                    |
-| `chats`       | `ChatsRequest`        | `Vec<ChatInfo>`             | `{ "limit": 50 }` default                          |
-| `groups`      | `GroupsRequest`       | `Vec<ChatInfo>`             |                                                    |
-| `unread`      | `UnreadRequest`       | `Vec<ChatInfo>`             |                                                    |
-| `search`      | `SearchRequest`       | `Vec<ContactInfo>`          | `{ "query": "..." }`                               |
-| `messages`    | `MessagesRequest`     | `Vec<MessageInfo>`          | accepts either `name` or `chat`; mirrors CLI rules |
-| `send`        | `SendRequest`         | `SendResult`                | `--as` (bot send) is not supported by `serve` v1   |
-| `download`    | `DownloadRequest`     | `DownloadReport`            | `output_dir` resolved inside the container         |
-| `mark_read`   | `MarkReadRequest`     | `null`                      |                                                    |
-| `mark_unread` | `MarkUnreadRequest`   | `null`                      |                                                    |
-| `sync`        | `SyncRequest`         | `HashMap<String, SyncResult>` | HWM map moves into `args.hwm`; see [Sync](#sync) |
+| `cmd`         | Args struct           | Result type                   |
+| ------------- | --------------------- | ----------------------------- |
+| `whoami`      | _none_                | `UserInfo`                    |
+| `chats`       | `ChatsRequest`        | `Vec<ChatInfo>`               |
+| `groups`      | `GroupsRequest`       | `Vec<ChatInfo>`               |
+| `unread`      | `UnreadRequest`       | `Vec<ChatInfo>`               |
+| `search`      | `SearchRequest`       | `Vec<ContactInfo>`            |
+| `messages`    | `MessagesRequest`     | `Vec<MessageInfo>`            |
+| `send`        | `SendRequest`         | `SendResult`                  |
+| `download`    | `DownloadRequest`     | `DownloadReport`              |
+| `mark_read`   | `MarkReadRequest`     | `null`                        |
+| `mark_unread` | `MarkUnreadRequest`   | `null`                        |
+| `sync`        | `SyncRequest`         | `HashMap<String, SyncResult>` |
 
-Notably **excluded**: `auth`, `auth bot`, `auth status`. These are interactive and/or modify on-disk credentials; the operator must stop `tg serve` before running them. Attempting `cmd: "auth"` returns `{"ok": false, "error": "auth is not available over serve; run \`tg auth\` directly"}`.
+Notably excluded: `auth`, `auth bot`, `auth status`, `send --as <bot>`. These run in-process always.
 
-Bot sends (`--as`) are excluded from v1 because they use the HTTP API rather than the shared TDLib client; adding them is a clean follow-up.
-
-### Sync
-
-`sync` is the one command whose CLI form takes structured stdin. In `serve` mode that input moves into the request envelope:
+For `sync`, the HWM map that today comes from stdin moves into `args.hwm`:
 
 ```json
 {"id": "s1", "cmd": "sync", "args": {
@@ -102,165 +166,153 @@ Bot sends (`--as`) are excluded from v1 because they use the HTTP API rather tha
 }}
 ```
 
-Today's `sync` writes per-chat results to stdout as a single pretty-printed JSON object after the run completes. In `serve`, the same map is the `result`. Progress lines that today go to stdout move to stderr (none exist today beyond the final dump, so this is mostly a no-op). The `--reconcile-days` flag becomes `args.reconcile_days: <u32 | null>`.
+When `tg sync` is run as a client (i.e. `tg serve` is up), it reads the same HWM JSON from stdin as today, packages it into `args.hwm`, sends the request, and prints the response `result` to stdout exactly as today.
 
 ## Architecture
 
 ### New module: `src/commands/serve.rs`
 
-Owns the request/response loop:
+Owns the listener loop and dispatch table:
 
 ```rust
-pub async fn run(client: &mut TdLibClient) -> Result<()>;
+pub async fn run(client: TdLibClient) -> Result<()>;
 ```
 
 It:
 
-1. Calls `client.start().await?` once at startup.
-2. Spawns a stdin reader (either a blocking thread feeding a `tokio::sync::mpsc` channel, or `tokio::io::BufReader<Stdin>::lines()`).
-3. Reads lines one at a time. For each line:
-   a. Parses into `Request` (`{id, cmd, args}` with `serde_json::Value` for `args`).
-   b. Dispatches to a per-command handler.
-   c. Writes the response line to stdout and flushes.
-4. On stdin EOF or SIGTERM: breaks the loop and returns. `main.rs` always calls `client.shutdown().await` afterwards.
+1. Resolves the socket path, handles stale-socket cleanup.
+2. Wraps the client in `Arc<Mutex<TdLibClient>>`.
+3. Calls `client.start().await?` (under the mutex, once).
+4. `bind()`s the Unix socket and starts accepting.
+5. Spawns a task per connection. Each task reads NDJSON lines, dispatches under the mutex, writes responses.
+6. Installs a SIGTERM/SIGINT handler that triggers clean shutdown.
+
+The dispatch function is the unit-testable seam:
+
+```rust
+pub async fn dispatch(client: &TdLibClient, req: Request) -> Response;
+```
+
+Where `Request { id, cmd, args }` and `Response { id, ok, result | error }`.
+
+### New module: `src/client_proxy.rs` (name TBD)
+
+Owns the client-side "try socket first, else in-process" decision:
+
+```rust
+pub enum Transport {
+    Socket(UnixStream),
+    InProcess(TdLibClient),
+}
+
+pub async fn connect() -> Transport;
+pub async fn request<R: Serialize, T: DeserializeOwned>(
+    transport: &mut Transport,
+    cmd: &str,
+    args: R,
+    in_process: impl FnOnce(&TdLibClient) -> Future<Output = Result<T>>,
+) -> Result<T>;
+```
+
+The exact shape of this abstraction is a plan-level decision — the cleanest version is probably a small `Transport` enum plus per-command thin wrappers in `main.rs`. The important invariant is that the **handler logic only lives in one place** (`commands/<name>.rs::handle`) and is called either by the server (on TDLib) or by the in-process fallback (also on TDLib).
 
 ### Handler factoring
 
-Today, `main.rs::run_command` couples three things per command: clap-arg extraction, target/recipient resolution, and the actual TDLib call. `serve` needs the second and third parts without the first.
+Today, `main.rs::run_command` couples three things per command: clap-arg extraction, target resolution, and the TDLib call. The new design needs the second and third reusable in two contexts (server-side dispatch, client-side fallback) without the first.
 
-Refactor each `commands/<name>.rs` to expose a function that takes a typed `<Name>Request` struct (or primitive args, where the existing handler already does) and returns a `Result<<ResultType>>`. Both code paths call that function:
-
-```
-clap args  ──► from_cli ──►  ChatsRequest ──┐
-                                            ├──► chats::handle(&client, req) ──► Vec<ChatInfo>
-serve args ──► serde_json::from_value ──────┘
-```
-
-Where the existing handler already takes primitive args (e.g. `messages::get_messages(client, target, limit, since_utc, oldest_first)`), the new `handle` function is a thin wrapper that constructs those primitives from the request struct. No semantic changes to the inner handlers.
-
-The `<Name>Request` structs live in a new `src/commands/request.rs` (or per-command, beside each handler — to be decided in the plan). They derive `Deserialize`, with `#[serde(default)]` on optional fields so omitted keys behave like the CLI defaults (e.g. `limit: 50`).
-
-The clap `*Args` structs in `cli.rs` are unchanged. Conversions live in `main.rs` (or beside each handler) and are mechanical: `ChatsArgs { limit } → ChatsRequest { limit }`.
-
-### Dispatcher
-
-A single `match cmd.as_str()` in `serve.rs` routes to handlers:
+Refactor each `commands/<name>.rs` to expose:
 
 ```rust
-let result: Result<serde_json::Value> = match req.cmd.as_str() {
-    "whoami"      => to_value(whoami::handle(client).await?),
-    "chats"       => to_value(chats::handle(client, from_value(req.args)?).await?),
-    "messages"    => to_value(messages::handle(client, from_value(req.args)?).await?),
-    // ...
-    "auth" | "auth_bot" | "auth_status" => Err(TgError::Other(
-        "auth is not available over serve; run `tg auth` directly".into())),
-    other => Err(TgError::Other(format!("unknown command: {other}"))),
-};
+pub async fn handle(
+    client: &TdLibClient,
+    req: <Name>Request,
+) -> Result<<ResultType>>;
 ```
 
-Where `to_value` uses `serde_json::to_value` and `()` → `Value::Null`.
+Both the server dispatcher and the in-process fallback in `main.rs` call this. The `<Name>Request` structs derive `Deserialize` and `Serialize` (the latter so clients can build wire requests). They live next to their handlers (e.g. `commands/chats.rs` defines `ChatsRequest`).
 
-### Concurrency
+The clap `*Args` structs in `cli.rs` stay; conversion `*Args → *Request` is a mechanical `From` impl alongside each request struct.
 
-Strictly serial. The dispatcher awaits each handler to completion before reading the next line. This matches the current `main.rs::run_command` model exactly — no new concurrency invariants for TDLib to worry about. A slow `download` blocks subsequent requests; mycelium is expected to tear down the session and respawn if a command hangs (per the brief).
+### Output rendering
 
-### Stdout discipline
-
-Two rules:
-
-1. Every byte written to stdout is part of a JSON response line, ending in `\n`. Nothing else.
-2. All other output — handler-internal `eprintln!`s, panic messages, TDLib chatter — goes to stderr.
-
-To enforce rule 2, audit existing handlers for any `println!` / `print!` calls and either remove them or route them through `eprintln!`. A quick grep shows the suspects are:
-
-- `messages::run` prints an `eprintln!` already when filtering returns empty (fine).
-- `sync` currently does its final dump via `println!` from `main.rs` — that's the `main.rs` caller's responsibility, so handlers themselves are clean.
-
-If any future handler prints to stdout it will silently corrupt the channel. A simple `#![deny(clippy::print_stdout)]` lint on `commands/` would catch this; whether to add it is left to the plan.
-
-### Lifecycle
-
-Startup:
-
-1. `main.rs` loads credentials and constructs `TdLibClient` (same as today).
-2. Routes `Command::Serve` to `serve::run(&mut client)`.
-3. `serve::run` calls `client.start().await?` and enters the loop.
-
-Shutdown triggers:
-
-- **Stdin EOF** (caller closed the pipe): break the loop cleanly.
-- **SIGTERM / SIGINT**: install a `tokio::signal` handler that flips an `AtomicBool`; the loop checks it between requests. In-flight request is allowed to complete (per "tear down + respawn for hangs" — graceful shutdown does not pre-empt a long `download`). For SIGKILL or container kill, the process dies and TDLib state stays consistent on disk because TDLib commits incrementally.
-
-In all clean exits, `main.rs` calls `client.shutdown().await` (the existing path). Exit code `0`.
-
-### Container assumption
-
-`podman exec -i tg tg serve` runs a new `tg serve` instance per `exec` call inside the running container. The expected usage is: mycelium holds **one** long-lived `serve` child (one `podman exec -i`), writes many requests over its lifetime, and closes stdin when shutting down. If mycelium restarts, it gets a cold TDLib but TDLib's on-disk session survives — auth is preserved. This document does not change anything about the container itself; the existing `Containerfile` already builds `tg`, and `tg serve` is just another subcommand.
+Unchanged. `output.rs::print_chats_table`, `print_messages_table`, `print_output`, `print_list` continue to take typed structs. The client deserialises the response `result` into the right typed struct and feeds it in, regardless of whether the result came from the socket or from in-process TDLib.
 
 ## Errors
 
-- Parse error on a request line → `{"id": <if extractable, else null>, "ok": false, "error": "invalid request: <serde message>"}`. Loop continues.
-- Unknown `cmd` → `{"id": ..., "ok": false, "error": "unknown command: <cmd>"}`. Loop continues.
-- Handler returns `Err(TgError::...)` → `{"id": ..., "ok": false, "error": "<TgError to_string>"}`. Loop continues.
-- Catastrophic TDLib failure (e.g. authentication revoked mid-session): handlers will return `Err`; subsequent requests will likely also fail. The server does not attempt to re-initialise TDLib. The operator decides whether to kill and restart.
+- Socket connect fails (refused, missing, permission denied): client silently falls back to in-process TDLib. No warning printed.
+- Socket connects but write fails partway: client surfaces `"error: tg serve connection dropped"` and exits non-zero. We do not retry by falling back, because TDLib state has already been mutated server-side for write commands.
+- Server-side request parse error: `{"ok": false, "error": "invalid request: <serde message>"}`. Connection stays open for further requests.
+- Server-side unknown `cmd`: `{"ok": false, "error": "unknown command: <cmd>"}`.
+- Server-side handler error: `{"ok": false, "error": "<TgError to_string>"}`.
+- Server detects another instance already running on the socket path: exits 1 with `tg serve: already running at <path>`.
 
 ## Out of Scope (v1)
 
-- Authentication commands (`auth`, `auth bot`, `auth status`).
-- Bot sends (`send --as <bot>`).
+- Authentication commands over the socket.
+- Bot sends (`send --as <bot>`) over the socket.
+- Per-request cancellation or timeouts. A hung `download` blocks the channel; caller decides whether to wait or kill+restart the server.
 - Streaming responses (multiple frames per request id). All responses are single frames.
-- Per-request cancellation or timeout. Caller tears down + respawns.
-- Multi-client concurrency (multiple parallel `podman exec` sessions). Single client only; document it in the README.
-- Update notifications (TDLib `updateNewMessage` etc.). Protocol leaves room for `{"event": ...}` frames but the v1 server never emits any.
+- TLS / authentication on the socket itself. Filesystem permissions (`0600`) are the access boundary.
+- Cross-host or network transports. Unix socket only.
+- Update notifications (TDLib `updateNewMessage` etc.). Protocol reserves `{"event": ...}` for them; v1 server never emits any.
 - Machine-readable error codes / typed error envelopes. Strings only in v1.
+- Automatic server startup (no systemd unit, no launchd plist). Operator runs `tg serve` themselves (or via the container's entrypoint).
+- Hot reload / re-auth without restart. Re-running `tg auth` requires stopping `tg serve` first.
 
 ## Testing
 
-### Unit (in `src/commands/serve.rs`)
+### Unit (`src/commands/serve.rs`)
 
-Dispatcher tests using a `MockClient` (already exists in `src/client.rs`'s `mock` module):
+Dispatcher tests using `MockClient`:
 
-- Request with valid `cmd: "whoami"` returns `{"ok": true, "result": {...}}` with `id` echoed.
-- Request with unknown `cmd` returns `{"ok": false, "error": "unknown command: ..."}` and the loop continues to process the next request.
-- Request with malformed JSON returns `{"ok": false, "error": "invalid request: ..."}` with `id: null`.
-- Request that triggers a handler error returns `{"ok": false}` with the error message verbatim.
-- Multiple requests are processed in arrival order; response `id`s match input `id`s in order.
+- Valid `cmd: "whoami"` → `{ok: true, result: ...}` with `id` echoed.
+- Unknown `cmd` → `{ok: false, error: "unknown command: ..."}`, loop continues.
+- Malformed JSON → `{ok: false, error: "invalid request: ..."}`, `id: null`.
+- Handler error → `{ok: false, error: ...}` with message verbatim.
+- Sequential requests on one connection: responses arrive in order with matching `id`s.
+- Concurrent connections: requests serialise through the mutex; per-connection ordering preserved.
 
-These tests drive `serve::dispatch_one(client, line) -> String` (a pure function) directly, no real stdio.
+These drive `serve::dispatch` directly, no real sockets.
 
-### Integration (in `tests/`)
+### Unit (client-side routing)
 
-A new `tests/serve_integration.rs` (`#[cfg(feature = "integration")]` or behind a `--ignored` marker — to be decided in the plan, mirroring whatever convention `tests/` already uses):
+Test the `Transport` selection in isolation: given a socket path that exists vs. doesn't exist, the proxy resolves to `Transport::Socket` vs. `Transport::InProcess`. Use a real `UnixListener` bound to a tempdir path for the socket case (no TDLib required).
 
-1. Spawn `tg serve` as a child process via `std::process::Command` with piped stdin/stdout.
-2. The test uses the mock-backed code paths where possible; if a real TDLib is required, gate the test behind an env var (`TG_SERVE_INTEGRATION=1`) so CI doesn't try to talk to Telegram.
-3. Write two requests (`whoami`, `chats --limit 1`) to stdin.
-4. Read two response lines from stdout.
-5. Assert: both responses parse as JSON, `id` values match request order, `ok: true`, expected `result` shape.
-6. Close stdin. Wait for process exit. Assert exit code 0.
+### Integration (`tests/serve_integration.rs`)
 
-If standing up a real TDLib in CI is impractical, the integration test reuses the existing test harness pattern (whatever `tests/` already does for end-to-end coverage) and the round-trip assertions stay; the inner data is mocked.
+Spawn `tg serve` as a child process pointed at a tempdir socket via `TG_SERVE_SOCKET`. Use the `MockClient`-backed binary if feasible; otherwise gate on `TG_SERVE_INTEGRATION=1` env var.
+
+Scenarios:
+
+1. **Round-trip on one connection.** Open a Unix socket, write `whoami` + `chats --limit 1` requests, read two response lines, assert `id`s match request order, `ok: true`, expected shapes.
+2. **Parallel connections.** Open two sockets, send `chats` on each concurrently, both succeed; the server's mutex serialised them but both got correct responses.
+3. **Stale socket cleanup.** Pre-create a dead socket file at the target path. Server starts, detects no listener, unlinks, binds successfully.
+4. **Already-running detection.** Start one `tg serve`, then start a second pointed at the same socket. Second exits `1` with the "already running" message; first keeps serving.
+5. **Clean shutdown.** Send SIGTERM to a running server. It finishes any in-flight request, unlinks the socket, exits `0`.
+6. **CLI fallback.** With no `tg serve` running, run a `tg whoami` (mocked-TDLib build) and assert it works the same as today.
 
 ## README updates
 
-The existing README has a "Bulk sync" section that documents `tg sync` as the machine-use entry point. Replace it with a broader **"Machine use"** section that:
+The existing README has a "Bulk sync" section that documents `tg sync`. Replace it with a broader **"Machine use"** section that:
 
-1. Leads with `tg serve` as the preferred entry point for any long-running caller: explains the wire protocol, the request/response shape, lifecycle, error semantics, and the single-client constraint.
-2. Retains `tg sync` as a one-shot variant for callers that only need bulk message ingestion and don't want to maintain a long-lived child.
-3. Documents the operational constraint that `tg auth` must be run with the `serve` session stopped, since both want exclusive access to TDLib's on-disk database.
-4. Shows the `podman exec -i tg tg serve` invocation pattern with a sample request/response exchange.
+1. Leads with `tg serve`: what it does (keeps TDLib warm), how to start it (`tg serve` or `podman exec -d tg tg serve` for backgrounded use), where the socket lives, the `TG_SERVE_SOCKET` override.
+2. Explains the transparent client-side routing: every other `tg <cmd>` automatically uses the server if it's up, otherwise behaves exactly as today.
+3. Documents the wire protocol for external (non-`tg`-CLI) clients that want to speak NDJSON directly.
+4. Documents the operational constraint that `tg auth` must be run with `tg serve` stopped.
+5. Retains `tg sync` as a bulk-ingest variant that works whether or not the server is up (with the server, it's just a single request through the same socket).
 
-The existing "Bulk sync" example (`echo '{"123": 42}' | tg sync`) stays, but moves under a "One-shot bulk sync" subheading.
+The existing `echo '{"123": 42}' | tg sync` example stays under a "Bulk sync" subheading.
 
 ## File touch list
 
 - `src/cli.rs` — add `Command::Serve` variant (no args).
-- `src/main.rs` — route `Command::Serve` to `serve::run`; ensure clean shutdown path still runs.
+- `src/main.rs` — route `Command::Serve` to `serve::run`; refactor every other command's branch to go through the client-proxy abstraction.
 - `src/commands/mod.rs` — export new `serve` module.
-- `src/commands/serve.rs` — new. Request/response types, dispatcher, loop, signal handling.
-- `src/commands/request.rs` (or per-command request structs) — new. `Deserialize`-derived request structs and `From<*Args>` impls.
-- `src/commands/{chats,groups,unread,messages,search,send,download,mark_read,mark_unread,sync,whoami}.rs` — add or expose a `handle(client, req) -> Result<...>` function for each. Existing internals untouched.
+- `src/commands/serve.rs` — new. Socket listener, dispatcher, signal handling.
+- `src/client_proxy.rs` (name TBD) — new. Transport detection + per-command request/response helpers.
+- `src/commands/{chats,groups,unread,messages,search,send,download,mark_read,mark_unread,sync,whoami}.rs` — add `handle(client, req)` function and per-command `*Request` struct (Serialize + Deserialize) and `From<*Args>` impl.
+- `src/auth.rs` — add a "is serve running" precheck that errors out cleanly with the stop-serve instruction.
 - `tests/serve_integration.rs` — new.
 - `README.md` — rewrite "Bulk sync" section as "Machine use".
 
-No changes to `auth.rs`, `bot_api.rs`, `client.rs`, `output.rs`, `credentials.rs`, `resolve.rs`, `error.rs`.
+No changes to `bot_api.rs`, `client.rs`, `output.rs`, `credentials.rs`, `resolve.rs`, `error.rs`.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -54,6 +54,9 @@ pub enum Command {
 
     /// Show your Telegram user info (ID, name, username, phone)
     Whoami,
+
+    /// Run a long-lived TDLib server on a Unix socket so other `tg` commands skip cold start
+    Serve,
 }
 
 #[derive(Parser, Debug)]
@@ -751,6 +754,12 @@ mod tests {
         // --as alone without a recipient should fail
         let cli = Cli::try_parse_from(["tg", "send", "--as", "@mybot", "-m", "hi"]);
         assert!(cli.is_err());
+    }
+
+    #[test]
+    fn parse_serve() {
+        let cli = Cli::parse_from(["tg", "serve"]);
+        assert!(matches!(cli.command, Command::Serve));
     }
 
     #[test]

--- a/src/commands/chats.rs
+++ b/src/commands/chats.rs
@@ -1,9 +1,40 @@
+use serde::{Deserialize, Serialize};
+
+use crate::cli::ChatsArgs;
 use crate::client::TelegramClient;
 use crate::error::Result;
 use crate::output::ChatInfo;
 
+fn default_limit() -> i32 {
+    50
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChatsRequest {
+    #[serde(default = "default_limit")]
+    pub limit: i32,
+}
+
+impl Default for ChatsRequest {
+    fn default() -> Self {
+        Self {
+            limit: default_limit(),
+        }
+    }
+}
+
+impl From<ChatsArgs> for ChatsRequest {
+    fn from(args: ChatsArgs) -> Self {
+        Self { limit: args.limit }
+    }
+}
+
 pub async fn list_chats<C: TelegramClient>(client: &C, limit: i32) -> Result<Vec<ChatInfo>> {
     client.get_chats(limit).await
+}
+
+pub async fn handle<C: TelegramClient>(client: &C, req: ChatsRequest) -> Result<Vec<ChatInfo>> {
+    list_chats(client, req.limit).await
 }
 
 #[cfg(test)]
@@ -24,5 +55,23 @@ mod tests {
         let client = MockClient::default();
         let chats = list_chats(&client, 1).await.unwrap();
         assert_eq!(chats.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn handle_uses_request_limit() {
+        let client = MockClient::default();
+        let chats = handle(&client, ChatsRequest { limit: 1 }).await.unwrap();
+        assert_eq!(chats.len(), 1);
+    }
+
+    #[test]
+    fn request_default_limit_is_50() {
+        assert_eq!(ChatsRequest::default().limit, 50);
+    }
+
+    #[test]
+    fn request_deserializes_with_missing_limit() {
+        let req: ChatsRequest = serde_json::from_str("{}").unwrap();
+        assert_eq!(req.limit, 50);
     }
 }

--- a/src/commands/download.rs
+++ b/src/commands/download.rs
@@ -1,8 +1,40 @@
 use std::path::PathBuf;
 
+use serde::{Deserialize, Serialize};
+
+use crate::cli::DownloadArgs;
 use crate::client::{DownloadOptions, TelegramClient};
 use crate::error::Result;
 use crate::output::DownloadReport;
+
+fn default_output_dir() -> PathBuf {
+    PathBuf::from(".")
+}
+
+fn default_priority() -> i32 {
+    16
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DownloadRequest {
+    pub chat: i64,
+    pub message: i64,
+    #[serde(default = "default_output_dir")]
+    pub output_dir: PathBuf,
+    #[serde(default = "default_priority")]
+    pub priority: i32,
+}
+
+impl From<DownloadArgs> for DownloadRequest {
+    fn from(args: DownloadArgs) -> Self {
+        Self {
+            chat: args.chat,
+            message: args.message,
+            output_dir: args.output_dir,
+            priority: args.priority,
+        }
+    }
+}
 
 pub async fn download_message_media<C: TelegramClient>(
     client: &C,
@@ -20,6 +52,10 @@ pub async fn download_message_media<C: TelegramClient>(
         .await
 }
 
+pub async fn handle<C: TelegramClient>(client: &C, req: DownloadRequest) -> Result<DownloadReport> {
+    download_message_media(client, req.chat, req.message, req.output_dir, req.priority).await
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -35,5 +71,26 @@ mod tests {
         assert_eq!(report.chat_id, 1);
         assert_eq!(report.message_id, 2);
         assert_eq!(report.status, DownloadStatus::NoDownloadableMedia);
+    }
+
+    #[tokio::test]
+    async fn handle_calls_client_with_fields() {
+        let client = MockClient::default();
+        let req = DownloadRequest {
+            chat: 7,
+            message: 8,
+            output_dir: PathBuf::from("/tmp"),
+            priority: 16,
+        };
+        let report = handle(&client, req).await.unwrap();
+        assert_eq!(report.chat_id, 7);
+        assert_eq!(report.message_id, 8);
+    }
+
+    #[test]
+    fn request_deserializes_with_defaults() {
+        let req: DownloadRequest = serde_json::from_str(r#"{"chat":1,"message":2}"#).unwrap();
+        assert_eq!(req.output_dir, PathBuf::from("."));
+        assert_eq!(req.priority, 16);
     }
 }

--- a/src/commands/groups.rs
+++ b/src/commands/groups.rs
@@ -1,9 +1,40 @@
+use serde::{Deserialize, Serialize};
+
+use crate::cli::GroupsArgs;
 use crate::client::TelegramClient;
 use crate::error::Result;
 use crate::output::ChatInfo;
 
+fn default_limit() -> i32 {
+    50
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GroupsRequest {
+    #[serde(default = "default_limit")]
+    pub limit: i32,
+}
+
+impl Default for GroupsRequest {
+    fn default() -> Self {
+        Self {
+            limit: default_limit(),
+        }
+    }
+}
+
+impl From<GroupsArgs> for GroupsRequest {
+    fn from(args: GroupsArgs) -> Self {
+        Self { limit: args.limit }
+    }
+}
+
 pub async fn list_groups<C: TelegramClient>(client: &C, limit: i32) -> Result<Vec<ChatInfo>> {
     client.get_groups(limit).await
+}
+
+pub async fn handle<C: TelegramClient>(client: &C, req: GroupsRequest) -> Result<Vec<ChatInfo>> {
+    list_groups(client, req.limit).await
 }
 
 #[cfg(test)]
@@ -17,5 +48,12 @@ mod tests {
         let groups = list_groups(&client, 50).await.unwrap();
         assert_eq!(groups.len(), 1);
         assert_eq!(groups[0].name, "Family Chat");
+    }
+
+    #[tokio::test]
+    async fn handle_uses_request_limit() {
+        let client = MockClient::default();
+        let groups = handle(&client, GroupsRequest { limit: 50 }).await.unwrap();
+        assert_eq!(groups.len(), 1);
     }
 }

--- a/src/commands/mark_read.rs
+++ b/src/commands/mark_read.rs
@@ -1,9 +1,29 @@
+use serde::{Deserialize, Serialize};
+
+use crate::cli::MarkReadArgs;
 use crate::client::TelegramClient;
-use crate::error::Result;
+use crate::error::{Result, TgError};
 
 pub enum ChatTarget {
     Id(i64),
     Name(String),
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct MarkReadRequest {
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub id: Option<i64>,
+}
+
+impl From<MarkReadArgs> for MarkReadRequest {
+    fn from(args: MarkReadArgs) -> Self {
+        Self {
+            name: args.name,
+            id: args.id,
+        }
+    }
 }
 
 pub async fn mark_as_read<C: TelegramClient>(client: &C, target: ChatTarget) -> Result<()> {
@@ -13,6 +33,19 @@ pub async fn mark_as_read<C: TelegramClient>(client: &C, target: ChatTarget) -> 
     };
 
     client.mark_chat_as_read(chat_id).await
+}
+
+pub async fn handle<C: TelegramClient>(client: &C, req: MarkReadRequest) -> Result<()> {
+    let target = if let Some(id) = req.id {
+        ChatTarget::Id(id)
+    } else if let Some(name) = req.name {
+        ChatTarget::Name(name)
+    } else {
+        return Err(TgError::Other(
+            "mark_read: either `id` or `name` is required".to_string(),
+        ));
+    };
+    mark_as_read(client, target).await
 }
 
 #[cfg(test)]
@@ -32,5 +65,24 @@ mod tests {
         let client = MockClient::default();
         let result = mark_as_read(&client, ChatTarget::Name("John".to_string())).await;
         assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn handle_by_id() {
+        let client = MockClient::default();
+        let req = MarkReadRequest {
+            id: Some(1),
+            ..Default::default()
+        };
+        handle(&client, req).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn handle_requires_id_or_name() {
+        let client = MockClient::default();
+        let err = handle(&client, MarkReadRequest::default())
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("either `id` or `name`"));
     }
 }

--- a/src/commands/mark_unread.rs
+++ b/src/commands/mark_unread.rs
@@ -1,9 +1,29 @@
+use serde::{Deserialize, Serialize};
+
+use crate::cli::MarkUnreadArgs;
 use crate::client::TelegramClient;
-use crate::error::Result;
+use crate::error::{Result, TgError};
 
 pub enum ChatTarget {
     Id(i64),
     Name(String),
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct MarkUnreadRequest {
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub id: Option<i64>,
+}
+
+impl From<MarkUnreadArgs> for MarkUnreadRequest {
+    fn from(args: MarkUnreadArgs) -> Self {
+        Self {
+            name: args.name,
+            id: args.id,
+        }
+    }
 }
 
 pub async fn mark_as_unread<C: TelegramClient>(client: &C, target: ChatTarget) -> Result<()> {
@@ -13,6 +33,19 @@ pub async fn mark_as_unread<C: TelegramClient>(client: &C, target: ChatTarget) -
     };
 
     client.mark_chat_as_unread(chat_id).await
+}
+
+pub async fn handle<C: TelegramClient>(client: &C, req: MarkUnreadRequest) -> Result<()> {
+    let target = if let Some(id) = req.id {
+        ChatTarget::Id(id)
+    } else if let Some(name) = req.name {
+        ChatTarget::Name(name)
+    } else {
+        return Err(TgError::Other(
+            "mark_unread: either `id` or `name` is required".to_string(),
+        ));
+    };
+    mark_as_unread(client, target).await
 }
 
 #[cfg(test)]
@@ -32,5 +65,24 @@ mod tests {
         let client = MockClient::default();
         let result = mark_as_unread(&client, ChatTarget::Name("John".to_string())).await;
         assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn handle_by_id() {
+        let client = MockClient::default();
+        let req = MarkUnreadRequest {
+            id: Some(1),
+            ..Default::default()
+        };
+        handle(&client, req).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn handle_requires_id_or_name() {
+        let client = MockClient::default();
+        let err = handle(&client, MarkUnreadRequest::default())
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("either `id` or `name`"));
     }
 }

--- a/src/commands/messages.rs
+++ b/src/commands/messages.rs
@@ -1,6 +1,51 @@
+use serde::{Deserialize, Serialize};
+
+use crate::cli::MessagesArgs;
 use crate::client::{BoundaryResult, TelegramClient};
 use crate::error::{Result, TgError};
 use crate::output::MessageInfo;
+
+fn default_limit() -> i32 {
+    20
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MessagesRequest {
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub chat: Option<i64>,
+    #[serde(default = "default_limit")]
+    pub limit: i32,
+    #[serde(default)]
+    pub since_utc: Option<String>,
+    #[serde(default)]
+    pub oldest_first: bool,
+}
+
+impl Default for MessagesRequest {
+    fn default() -> Self {
+        Self {
+            name: None,
+            chat: None,
+            limit: default_limit(),
+            since_utc: None,
+            oldest_first: false,
+        }
+    }
+}
+
+impl From<MessagesArgs> for MessagesRequest {
+    fn from(args: MessagesArgs) -> Self {
+        Self {
+            name: args.name,
+            chat: args.chat,
+            limit: args.limit,
+            since_utc: args.since_utc,
+            oldest_first: args.oldest_first,
+        }
+    }
+}
 
 /// Milliseconds to wait before a single retry of `get_boundary_message_id`.
 /// The warmup fetch and `wait_for_sync()` handle most sync cases, but
@@ -116,6 +161,30 @@ pub async fn get_messages<C: TelegramClient>(
     };
 
     Ok(MessagesResult { chat_id, messages })
+}
+
+pub async fn handle<C: TelegramClient>(
+    client: &C,
+    req: MessagesRequest,
+) -> Result<Vec<MessageInfo>> {
+    let target = if let Some(id) = req.chat {
+        ChatTarget::Id(id)
+    } else if let Some(name) = req.name {
+        ChatTarget::Name(name)
+    } else {
+        return Err(TgError::Other(
+            "messages: either `chat` or `name` is required".to_string(),
+        ));
+    };
+    let result = get_messages(
+        client,
+        target,
+        req.limit,
+        req.since_utc.as_deref(),
+        req.oldest_first,
+    )
+    .await?;
+    Ok(result.messages)
 }
 
 #[cfg(test)]

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -7,6 +7,7 @@ pub mod mark_unread;
 pub mod messages;
 pub mod search;
 pub mod send;
+pub mod serve;
 pub mod sync;
 pub mod unread;
 pub mod whoami;

--- a/src/commands/search.rs
+++ b/src/commands/search.rs
@@ -1,12 +1,30 @@
+use serde::{Deserialize, Serialize};
+
+use crate::cli::SearchArgs;
 use crate::client::TelegramClient;
 use crate::error::Result;
 use crate::output::ContactInfo;
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct SearchRequest {
+    pub query: String,
+}
+
+impl From<SearchArgs> for SearchRequest {
+    fn from(args: SearchArgs) -> Self {
+        Self { query: args.query }
+    }
+}
 
 pub async fn search_contacts<C: TelegramClient>(
     client: &C,
     query: &str,
 ) -> Result<Vec<ContactInfo>> {
     client.search_contacts(query).await
+}
+
+pub async fn handle<C: TelegramClient>(client: &C, req: SearchRequest) -> Result<Vec<ContactInfo>> {
+    search_contacts(client, &req.query).await
 }
 
 #[cfg(test)]
@@ -34,5 +52,15 @@ mod tests {
         let client = MockClient::default();
         let contacts = search_contacts(&client, "xyz").await.unwrap();
         assert!(contacts.is_empty());
+    }
+
+    #[tokio::test]
+    async fn handle_runs_search() {
+        let client = MockClient::default();
+        let req = SearchRequest {
+            query: "John".to_string(),
+        };
+        let contacts = handle(&client, req).await.unwrap();
+        assert_eq!(contacts.len(), 1);
     }
 }

--- a/src/commands/send.rs
+++ b/src/commands/send.rs
@@ -1,11 +1,45 @@
+use serde::{Deserialize, Serialize};
+
+use crate::cli::SendArgs;
 use crate::client::TelegramClient;
-use crate::error::Result;
+use crate::error::{Result, TgError};
 use crate::output::SendResult;
 
 pub enum SendTarget {
     Id(i64),
     Name(String),
     Group(String),
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct SendRequest {
+    pub message: String,
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub id: Option<i64>,
+    #[serde(default)]
+    pub to: Option<String>,
+    #[serde(default)]
+    pub group: Option<String>,
+}
+
+/// Convert clap args to a `SendRequest`. Panics if `--as <bot>` is set, because
+/// bot sends use the HTTP API path and never reach this code.
+impl From<SendArgs> for SendRequest {
+    fn from(args: SendArgs) -> Self {
+        debug_assert!(
+            args.send_as.is_none(),
+            "bot sends (--as) must be routed before SendRequest"
+        );
+        Self {
+            message: args.message,
+            name: args.name,
+            id: args.id,
+            to: args.to,
+            group: args.group,
+        }
+    }
 }
 
 pub async fn send_message<C: TelegramClient>(
@@ -20,6 +54,29 @@ pub async fn send_message<C: TelegramClient>(
     };
 
     client.send_message(chat_id, message).await
+}
+
+pub async fn handle<C: TelegramClient>(client: &C, req: SendRequest) -> Result<SendResult> {
+    let target = if let Some(ref to) = req.to {
+        if let Ok(id) = to.parse::<i64>() {
+            SendTarget::Id(id)
+        } else {
+            let name = to.strip_prefix('@').unwrap_or(to);
+            SendTarget::Name(name.to_string())
+        }
+    } else if let Some(id) = req.id {
+        SendTarget::Id(id)
+    } else if let Some(group) = req.group {
+        SendTarget::Group(group)
+    } else if let Some(name) = req.name {
+        SendTarget::Name(name)
+    } else {
+        return Err(TgError::Other(
+            "send: one of `id`, `to`, `group`, or `name` is required".to_string(),
+        ));
+    };
+
+    send_message(client, target, &req.message).await
 }
 
 #[cfg(test)]
@@ -78,5 +135,62 @@ mod tests {
         let client = MockClient::default();
         let result = client.find_chat_by_username("JohnDoe").await;
         assert_eq!(result.unwrap(), 1);
+    }
+
+    #[tokio::test]
+    async fn handle_by_id() {
+        let client = MockClient::default();
+        let req = SendRequest {
+            message: "hi".to_string(),
+            id: Some(123),
+            ..Default::default()
+        };
+        let res = handle(&client, req).await.unwrap();
+        assert_eq!(res.chat_id, 123);
+    }
+
+    #[tokio::test]
+    async fn handle_by_name() {
+        let client = MockClient::default();
+        let req = SendRequest {
+            message: "hi".to_string(),
+            name: Some("John".to_string()),
+            ..Default::default()
+        };
+        handle(&client, req).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn handle_to_numeric_string_routes_to_id() {
+        let client = MockClient::default();
+        let req = SendRequest {
+            message: "hi".to_string(),
+            to: Some("123".to_string()),
+            ..Default::default()
+        };
+        let res = handle(&client, req).await.unwrap();
+        assert_eq!(res.chat_id, 123);
+    }
+
+    #[tokio::test]
+    async fn handle_to_at_username_strips_prefix() {
+        let client = MockClient::default();
+        let req = SendRequest {
+            message: "hi".to_string(),
+            to: Some("@John".to_string()),
+            ..Default::default()
+        };
+        handle(&client, req).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn handle_requires_recipient() {
+        let client = MockClient::default();
+        let req = SendRequest {
+            message: "hi".to_string(),
+            ..Default::default()
+        };
+        let err = handle(&client, req).await.unwrap_err();
+        assert!(err.to_string().contains("one of"));
     }
 }

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -1,0 +1,187 @@
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+use std::sync::Arc;
+
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::{UnixListener, UnixStream};
+use tokio::signal::unix::{SignalKind, signal};
+use tokio::sync::Mutex;
+use tokio::task::JoinSet;
+
+use crate::client::{TdLibClient, TelegramClient};
+use crate::error::{Result, TgError};
+use crate::serve::{self, RequestEnvelope, ResponseEnvelope};
+
+/// Maximum time to wait for in-flight per-connection tasks to drain after the
+/// listener stops accepting new connections.
+const SHUTDOWN_DRAIN_SECS: u64 = 5;
+
+/// Run the long-lived serve loop until SIGTERM/SIGINT or unrecoverable error.
+///
+/// Takes ownership of `client` and is responsible for shutting it down on exit.
+pub async fn run(mut client: TdLibClient) -> Result<()> {
+    let path = serve::socket_path().ok_or_else(|| {
+        TgError::Other("TG_SERVE_SOCKET is empty; refusing to start tg serve".to_string())
+    })?;
+
+    prepare_socket_path(&path).await?;
+
+    // Initialize TDLib once and wait for the post-auth update sync so every
+    // request served from here on sees a fully-synced cache.
+    client.start().await?;
+    client.wait_for_sync().await;
+
+    let listener = UnixListener::bind(&path)?;
+    if let Err(e) = std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)) {
+        eprintln!(
+            "tg serve: warning: failed to chmod socket {}: {e}",
+            path.display()
+        );
+    }
+
+    eprintln!("tg serve: listening at {}", path.display());
+
+    let client_arc = Arc::new(Mutex::new(client));
+    let mut tasks: JoinSet<()> = JoinSet::new();
+
+    let mut sigterm = signal(SignalKind::terminate())
+        .map_err(|e| TgError::Other(format!("install sigterm handler: {e}")))?;
+    let mut sigint = signal(SignalKind::interrupt())
+        .map_err(|e| TgError::Other(format!("install sigint handler: {e}")))?;
+
+    loop {
+        tokio::select! {
+            res = listener.accept() => {
+                match res {
+                    Ok((stream, _)) => {
+                        let client_arc = client_arc.clone();
+                        tasks.spawn(async move {
+                            if let Err(e) = handle_connection(stream, client_arc).await {
+                                eprintln!("tg serve: connection error: {e}");
+                            }
+                        });
+                    }
+                    Err(e) => {
+                        eprintln!("tg serve: accept error: {e}");
+                    }
+                }
+            }
+            _ = sigterm.recv() => break,
+            _ = sigint.recv() => break,
+        }
+    }
+
+    // Stop accepting and drain.
+    drop(listener);
+    let _ = tokio::time::timeout(std::time::Duration::from_secs(SHUTDOWN_DRAIN_SECS), async {
+        while tasks.join_next().await.is_some() {}
+    })
+    .await;
+    tasks.abort_all();
+    while tasks.join_next().await.is_some() {}
+
+    // Reclaim client and shut down TDLib cleanly.
+    let mut client = Arc::try_unwrap(client_arc)
+        .map_err(|_| TgError::Other("could not reclaim TDLib client at shutdown".to_string()))?
+        .into_inner();
+    client.shutdown().await;
+
+    // Best-effort socket cleanup.
+    let _ = std::fs::remove_file(&path);
+
+    Ok(())
+}
+
+/// Prepare the socket path: detect "already running", remove stale sockets,
+/// and ensure the parent directory exists.
+pub async fn prepare_socket_path(path: &Path) -> Result<()> {
+    if path.exists() {
+        match tokio::time::timeout(
+            std::time::Duration::from_millis(250),
+            UnixStream::connect(path),
+        )
+        .await
+        {
+            Ok(Ok(_)) => {
+                return Err(TgError::Other(format!(
+                    "tg serve: already running at {}",
+                    path.display()
+                )));
+            }
+            _ => {
+                // Stale socket — remove it before binding.
+                std::fs::remove_file(path)?;
+            }
+        }
+    }
+
+    if let Some(parent) = path.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    Ok(())
+}
+
+/// Read newline-delimited request envelopes from `stream`, dispatch each
+/// against the shared client (serializing access through the mutex), and
+/// write the response back. Returns when the peer closes the connection.
+pub async fn handle_connection<C: TelegramClient>(
+    stream: UnixStream,
+    client: Arc<Mutex<C>>,
+) -> Result<()> {
+    let (read, mut write) = stream.into_split();
+    let mut lines = BufReader::new(read).lines();
+
+    while let Some(line) = lines.next_line().await? {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let response = match serde_json::from_str::<RequestEnvelope>(&line) {
+            Ok(req) => {
+                let guard = client.lock().await;
+                serve::dispatch(&*guard, req).await
+            }
+            Err(e) => {
+                let id = extract_id(&line);
+                ResponseEnvelope::err(id, format!("invalid request: {e}"))
+            }
+        };
+        let mut out = serde_json::to_string(&response)?;
+        out.push('\n');
+        write.write_all(out.as_bytes()).await?;
+        write.flush().await?;
+    }
+    Ok(())
+}
+
+fn extract_id(line: &str) -> serde_json::Value {
+    serde_json::from_str::<serde_json::Value>(line)
+        .ok()
+        .and_then(|v| v.get("id").cloned())
+        .unwrap_or(serde_json::Value::Null)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_id_from_partial_request() {
+        let v = extract_id(r#"{"id":"abc","cmd":"oops""#); // truncated
+        assert!(v.is_null());
+    }
+
+    #[test]
+    fn extract_id_from_well_formed_object() {
+        let v = extract_id(r#"{"id":"abc","cmd":42}"#);
+        assert_eq!(v, serde_json::json!("abc"));
+    }
+
+    #[test]
+    fn extract_id_missing_returns_null() {
+        let v = extract_id(r#"{"cmd":"whoami"}"#);
+        assert!(v.is_null());
+    }
+}

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -1,8 +1,9 @@
+use std::io::ErrorKind;
 use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 use std::sync::Arc;
 
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::io::{AsyncBufRead, AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::{UnixListener, UnixStream};
 use tokio::signal::unix::{SignalKind, signal};
 use tokio::sync::Mutex;
@@ -15,6 +16,11 @@ use crate::serve::{self, RequestEnvelope, ResponseEnvelope};
 /// Maximum time to wait for in-flight per-connection tasks to drain after the
 /// listener stops accepting new connections.
 const SHUTDOWN_DRAIN_SECS: u64 = 5;
+
+/// Maximum byte length of a single NDJSON request line. Any peer that can
+/// open the socket can send arbitrary input, so this cap is what stops a
+/// malicious or buggy client from OOM-ing the long-lived daemon.
+const MAX_REQUEST_LINE_BYTES: usize = 1_048_576; // 1 MiB
 
 /// Run the long-lived serve loop until SIGTERM/SIGINT or unrecoverable error.
 ///
@@ -31,13 +37,17 @@ pub async fn run(mut client: TdLibClient) -> Result<()> {
     client.start().await?;
     client.wait_for_sync().await;
 
-    let listener = UnixListener::bind(&path)?;
-    if let Err(e) = std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)) {
-        eprintln!(
-            "tg serve: warning: failed to chmod socket {}: {e}",
-            path.display()
-        );
-    }
+    // Bind under a restrictive umask so the socket is created with mode 0600
+    // atomically — no window where another local user can connect to a
+    // world-accessible socket. Restore the previous umask immediately after.
+    let listener = bind_with_restricted_umask(&path)?;
+    // Defense in depth: explicitly chmod after bind. Failure is fatal —
+    // if we can't guarantee 0600 perms, refuse to serve.
+    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)).map_err(|e| {
+        // Clean up before bailing.
+        let _ = std::fs::remove_file(&path);
+        TgError::Other(format!("failed to chmod socket {}: {e}", path.display()))
+    })?;
 
     eprintln!("tg serve: listening at {}", path.display());
 
@@ -92,8 +102,31 @@ pub async fn run(mut client: TdLibClient) -> Result<()> {
     Ok(())
 }
 
+/// Bind a `UnixListener` at `path` with the process umask temporarily set to
+/// `0o077`, so the socket file is created mode `0600` from the kernel's
+/// perspective with no race window. Restores the prior umask before returning.
+fn bind_with_restricted_umask(path: &Path) -> Result<UnixListener> {
+    // SAFETY: libc::umask is process-global. This runs during single-threaded
+    // server startup before any tasks are spawned, so there is no concurrent
+    // filesystem caller whose umask we could trample.
+    let prev = unsafe { libc::umask(0o077) };
+    let result = UnixListener::bind(path).map_err(TgError::Io);
+    unsafe {
+        libc::umask(prev);
+    }
+    result
+}
+
 /// Prepare the socket path: detect "already running", remove stale sockets,
 /// and ensure the parent directory exists.
+///
+/// A socket is considered "stale" only when `connect()` returns
+/// `ConnectionRefused` (no listener is attached to it). Any other error
+/// — timeout, permission denied, ENOTSOCK, etc. — is treated as
+/// "possibly running" and causes us to refuse to start. This avoids the
+/// dangerous case where a slow-but-alive server's socket gets unlinked
+/// because we couldn't connect within the timeout, allowing two `tg serve`
+/// processes to compete for the same TDLib database.
 pub async fn prepare_socket_path(path: &Path) -> Result<()> {
     if path.exists() {
         match tokio::time::timeout(
@@ -108,9 +141,22 @@ pub async fn prepare_socket_path(path: &Path) -> Result<()> {
                     path.display()
                 )));
             }
-            _ => {
-                // Stale socket — remove it before binding.
+            Ok(Err(e)) if e.kind() == ErrorKind::ConnectionRefused => {
+                // Definitively no listener on a real Unix socket — safe to remove.
                 std::fs::remove_file(path)?;
+            }
+            Ok(Err(e)) => {
+                return Err(TgError::Other(format!(
+                    "tg serve: path {} exists and is not a stale socket (connect: {e}); refusing to start",
+                    path.display()
+                )));
+            }
+            Err(_) => {
+                return Err(TgError::Other(format!(
+                    "tg serve: path {} exists and connect timed out; another server may be running. \
+                     Refusing to remove. If you are sure no server is running, delete the file manually.",
+                    path.display()
+                )));
             }
         }
     }
@@ -132,12 +178,33 @@ pub async fn handle_connection<C: TelegramClient>(
     client: Arc<Mutex<C>>,
 ) -> Result<()> {
     let (read, mut write) = stream.into_split();
-    let mut lines = BufReader::new(read).lines();
+    let mut reader = BufReader::new(read);
 
-    while let Some(line) = lines.next_line().await? {
+    loop {
+        let mut line = String::new();
+        match read_line_bounded(&mut reader, &mut line, MAX_REQUEST_LINE_BYTES).await {
+            Ok(false) => break, // peer closed
+            Ok(true) => {}
+            Err(LineError::TooLong) => {
+                // Tell the peer what happened, then drop them. Continuing to
+                // parse on the same stream is dangerous — we don't know where
+                // we are in the request framing.
+                let resp = ResponseEnvelope::err(
+                    serde_json::Value::Null,
+                    format!(
+                        "request line exceeds {MAX_REQUEST_LINE_BYTES}-byte limit; connection closed"
+                    ),
+                );
+                let _ = write_response(&mut write, &resp).await;
+                break;
+            }
+            Err(LineError::Io(e)) => return Err(TgError::Io(e)),
+        }
+
         if line.trim().is_empty() {
             continue;
         }
+
         let response = match serde_json::from_str::<RequestEnvelope>(&line) {
             Ok(req) => {
                 let guard = client.lock().await;
@@ -148,11 +215,96 @@ pub async fn handle_connection<C: TelegramClient>(
                 ResponseEnvelope::err(id, format!("invalid request: {e}"))
             }
         };
-        let mut out = serde_json::to_string(&response)?;
-        out.push('\n');
-        write.write_all(out.as_bytes()).await?;
-        write.flush().await?;
+        write_response(&mut write, &response).await?;
     }
+    Ok(())
+}
+
+async fn write_response<W: AsyncWriteExt + Unpin>(
+    write: &mut W,
+    response: &ResponseEnvelope,
+) -> Result<()> {
+    let mut out = serde_json::to_string(response)?;
+    out.push('\n');
+    write.write_all(out.as_bytes()).await?;
+    write.flush().await?;
+    Ok(())
+}
+
+#[derive(Debug)]
+enum LineError {
+    Io(std::io::Error),
+    TooLong,
+}
+
+impl From<std::io::Error> for LineError {
+    fn from(e: std::io::Error) -> Self {
+        LineError::Io(e)
+    }
+}
+
+/// Read one `\n`-terminated line into `out`, capping at `max` bytes. Returns
+/// `Ok(true)` if a line was read (with trailing `\r?\n` stripped), `Ok(false)`
+/// on EOF before any bytes, and `Err(TooLong)` if the line exceeded the cap.
+/// On `TooLong`, the over-budget bytes have been consumed from the reader.
+async fn read_line_bounded<R: AsyncBufRead + Unpin>(
+    reader: &mut R,
+    out: &mut String,
+    max: usize,
+) -> std::result::Result<bool, LineError> {
+    let mut buf: Vec<u8> = Vec::with_capacity(256);
+    loop {
+        let available = reader.fill_buf().await?;
+        if available.is_empty() {
+            // EOF
+            if buf.is_empty() {
+                return Ok(false);
+            } else {
+                // Partial line at EOF — return what we have.
+                push_decoded(&buf, out)?;
+                return Ok(true);
+            }
+        }
+        match available.iter().position(|&b| b == b'\n') {
+            Some(nl_pos) => {
+                let take = nl_pos + 1;
+                if buf.len() + take > max + 1 {
+                    reader.consume(take);
+                    return Err(LineError::TooLong);
+                }
+                buf.extend_from_slice(&available[..take]);
+                reader.consume(take);
+                // strip \r?\n
+                if buf.ends_with(b"\n") {
+                    buf.pop();
+                }
+                if buf.ends_with(b"\r") {
+                    buf.pop();
+                }
+                push_decoded(&buf, out)?;
+                return Ok(true);
+            }
+            None => {
+                let n = available.len();
+                if buf.len() + n > max {
+                    reader.consume(n);
+                    return Err(LineError::TooLong);
+                }
+                buf.extend_from_slice(available);
+                reader.consume(n);
+            }
+        }
+    }
+}
+
+fn push_decoded(buf: &[u8], out: &mut String) -> std::result::Result<(), LineError> {
+    let s = std::str::from_utf8(buf).map_err(|_| {
+        LineError::Io(std::io::Error::new(
+            ErrorKind::InvalidData,
+            "request line is not valid UTF-8",
+        ))
+    })?;
+    out.push_str(s);
     Ok(())
 }
 
@@ -183,5 +335,106 @@ mod tests {
     fn extract_id_missing_returns_null() {
         let v = extract_id(r#"{"cmd":"whoami"}"#);
         assert!(v.is_null());
+    }
+
+    #[tokio::test]
+    async fn read_line_bounded_returns_short_lines() {
+        let data = b"hello\nworld\n";
+        let mut reader = tokio::io::BufReader::new(&data[..]);
+        let mut s = String::new();
+        assert!(read_line_bounded(&mut reader, &mut s, 64).await.unwrap());
+        assert_eq!(s, "hello");
+        s.clear();
+        assert!(read_line_bounded(&mut reader, &mut s, 64).await.unwrap());
+        assert_eq!(s, "world");
+        s.clear();
+        assert!(!read_line_bounded(&mut reader, &mut s, 64).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn read_line_bounded_rejects_oversized_line() {
+        let mut data = vec![b'A'; 1024];
+        data.push(b'\n');
+        let mut reader = tokio::io::BufReader::new(&data[..]);
+        let mut s = String::new();
+        let err = read_line_bounded(&mut reader, &mut s, 128)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, LineError::TooLong));
+    }
+
+    #[tokio::test]
+    async fn read_line_bounded_handles_partial_line_at_eof() {
+        let data = b"no-newline";
+        let mut reader = tokio::io::BufReader::new(&data[..]);
+        let mut s = String::new();
+        assert!(read_line_bounded(&mut reader, &mut s, 64).await.unwrap());
+        assert_eq!(s, "no-newline");
+    }
+
+    #[tokio::test]
+    async fn read_line_bounded_strips_crlf() {
+        let data = b"hello\r\n";
+        let mut reader = tokio::io::BufReader::new(&data[..]);
+        let mut s = String::new();
+        assert!(read_line_bounded(&mut reader, &mut s, 64).await.unwrap());
+        assert_eq!(s, "hello");
+    }
+
+    #[tokio::test]
+    async fn handle_connection_rejects_oversized_line_and_closes() {
+        use crate::client::mock::MockClient;
+        use tempfile::TempDir;
+        use tokio::io::AsyncReadExt;
+
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("big.sock");
+        let listener = UnixListener::bind(&path).unwrap();
+
+        let client = Arc::new(Mutex::new(MockClient::default()));
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            handle_connection(stream, client).await.unwrap();
+        });
+
+        // Give the listener a moment to be ready.
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+
+        let stream = UnixStream::connect(&path).await.unwrap();
+        let (read, mut write) = stream.into_split();
+
+        // Drive writes on a separate task so we can read the server's error
+        // response in parallel. The server is expected to close the
+        // connection mid-write once it sees too many bytes without a
+        // newline, so write errors here are expected and ignored.
+        let writer = tokio::spawn(async move {
+            let chunk = vec![b'A'; 64 * 1024];
+            // Up to 32 MiB; the server should kill us long before this.
+            for _ in 0..512 {
+                if write.write_all(&chunk).await.is_err() {
+                    break;
+                }
+            }
+        });
+
+        // Read what the server sends before it closes.
+        let mut response = String::new();
+        let _ = tokio::time::timeout(
+            std::time::Duration::from_secs(3),
+            tokio::io::AsyncReadExt::read_to_string(
+                &mut tokio::io::BufReader::new(read),
+                &mut response,
+            ),
+        )
+        .await;
+
+        let _ = writer.await;
+
+        assert!(
+            response.contains("exceeds") && response.contains("byte limit"),
+            "expected oversized-line error response, got: {response:?}"
+        );
+
+        server.await.unwrap();
     }
 }

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -385,7 +385,6 @@ mod tests {
     async fn handle_connection_rejects_oversized_line_and_closes() {
         use crate::client::mock::MockClient;
         use tempfile::TempDir;
-        use tokio::io::AsyncReadExt;
 
         let dir = TempDir::new().unwrap();
         let path = dir.path().join("big.sock");
@@ -397,42 +396,36 @@ mod tests {
             handle_connection(stream, client).await.unwrap();
         });
 
-        // Give the listener a moment to be ready.
-        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
-
         let stream = UnixStream::connect(&path).await.unwrap();
         let (read, mut write) = stream.into_split();
 
-        // Drive writes on a separate task so we can read the server's error
-        // response in parallel. The server is expected to close the
-        // connection mid-write once it sees too many bytes without a
-        // newline, so write errors here are expected and ignored.
-        let writer = tokio::spawn(async move {
-            let chunk = vec![b'A'; 64 * 1024];
-            // Up to 32 MiB; the server should kill us long before this.
-            for _ in 0..512 {
-                if write.write_all(&chunk).await.is_err() {
-                    break;
-                }
-            }
+        // Read the single error-response line on a task — read_line returns
+        // as soon as one `\n` arrives, so we don't depend on EOF timing.
+        let reader = tokio::spawn(async move {
+            let mut reader = BufReader::new(read);
+            let mut line = String::new();
+            let _ = tokio::time::timeout(
+                std::time::Duration::from_secs(10),
+                reader.read_line(&mut line),
+            )
+            .await;
+            line
         });
 
-        // Read what the server sends before it closes.
-        let mut response = String::new();
-        let _ = tokio::time::timeout(
-            std::time::Duration::from_secs(3),
-            tokio::io::AsyncReadExt::read_to_string(
-                &mut tokio::io::BufReader::new(read),
-                &mut response,
-            ),
-        )
-        .await;
+        // Push 2 MiB of data without a newline — more than the 1 MiB cap.
+        // Write errors are expected once the server closes the connection.
+        let chunk = vec![b'A'; 64 * 1024];
+        for _ in 0..32 {
+            if write.write_all(&chunk).await.is_err() {
+                break;
+            }
+        }
+        drop(write); // signal end of write side
 
-        let _ = writer.await;
-
+        let line = reader.await.unwrap();
         assert!(
-            response.contains("exceeds") && response.contains("byte limit"),
-            "expected oversized-line error response, got: {response:?}"
+            line.contains("exceeds") && line.contains("byte limit"),
+            "expected oversized-line error response, got: {line:?}"
         );
 
         server.await.unwrap();

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -1,5 +1,5 @@
 use std::io::ErrorKind;
-use std::os::unix::fs::PermissionsExt;
+use std::os::unix::fs::{FileTypeExt, PermissionsExt};
 use std::path::Path;
 use std::sync::Arc;
 
@@ -129,6 +129,20 @@ fn bind_with_restricted_umask(path: &Path) -> Result<UnixListener> {
 /// processes to compete for the same TDLib database.
 pub async fn prepare_socket_path(path: &Path) -> Result<()> {
     if path.exists() {
+        // Only consider unlinking if the path is actually a Unix socket. A
+        // regular file at the socket path is somebody else's data and must
+        // not be removed — refuse to start instead. This also normalises
+        // platform differences: on Linux, connect() to a non-socket can
+        // return ECONNREFUSED, which would otherwise trick us into deleting
+        // unrelated files.
+        let meta = std::fs::metadata(path)?;
+        if !meta.file_type().is_socket() {
+            return Err(TgError::Other(format!(
+                "tg serve: path {} exists and is not a socket; refusing to start",
+                path.display()
+            )));
+        }
+
         match tokio::time::timeout(
             std::time::Duration::from_millis(250),
             UnixStream::connect(path),
@@ -142,18 +156,18 @@ pub async fn prepare_socket_path(path: &Path) -> Result<()> {
                 )));
             }
             Ok(Err(e)) if e.kind() == ErrorKind::ConnectionRefused => {
-                // Definitively no listener on a real Unix socket — safe to remove.
+                // Real socket with no listener — safe to remove.
                 std::fs::remove_file(path)?;
             }
             Ok(Err(e)) => {
                 return Err(TgError::Other(format!(
-                    "tg serve: path {} exists and is not a stale socket (connect: {e}); refusing to start",
+                    "tg serve: socket at {} exists but connect failed unexpectedly ({e}); refusing to start",
                     path.display()
                 )));
             }
             Err(_) => {
                 return Err(TgError::Other(format!(
-                    "tg serve: path {} exists and connect timed out; another server may be running. \
+                    "tg serve: socket at {} exists and connect timed out; another server may be running. \
                      Refusing to remove. If you are sure no server is running, delete the file manually.",
                     path.display()
                 )));

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -1,15 +1,56 @@
 use std::collections::HashMap;
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::client::{BoundaryResult, TelegramClient};
+use crate::error::{Result, TgError};
 use crate::output::MessageInfo;
+
+fn default_sync_limit() -> i32 {
+    1000
+}
+
+/// Wire-format request for `sync`. The HWM map is keyed by stringified chat
+/// ID because JSON object keys must be strings.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SyncRequest {
+    #[serde(default)]
+    pub hwm: HashMap<String, i64>,
+    #[serde(default = "default_sync_limit")]
+    pub limit: i32,
+    #[serde(default)]
+    pub reconcile_days: Option<u32>,
+}
+
+impl Default for SyncRequest {
+    fn default() -> Self {
+        Self {
+            hwm: HashMap::new(),
+            limit: default_sync_limit(),
+            reconcile_days: None,
+        }
+    }
+}
+
+pub async fn handle<C: TelegramClient>(
+    client: &C,
+    req: SyncRequest,
+) -> Result<HashMap<i64, SyncResult>> {
+    let mut hwm_map = HashMap::with_capacity(req.hwm.len());
+    for (k, v) in req.hwm {
+        let id: i64 = k
+            .parse()
+            .map_err(|_| TgError::Other(format!("Invalid chat ID: {k}")))?;
+        hwm_map.insert(id, v);
+    }
+    Ok(sync_chats(client, hwm_map, req.limit, req.reconcile_days).await)
+}
 
 /// Milliseconds to wait before a single retry of `get_boundary_message_id`.
 const BOUNDARY_RETRY_DELAY_MS: u64 = 300;
 
 /// Per-chat sync outcome: either messages or an error description.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum SyncResult {
     Messages(Vec<MessageInfo>),

--- a/src/commands/unread.rs
+++ b/src/commands/unread.rs
@@ -1,9 +1,40 @@
+use serde::{Deserialize, Serialize};
+
+use crate::cli::UnreadArgs;
 use crate::client::TelegramClient;
 use crate::error::Result;
 use crate::output::ChatInfo;
 
+fn default_limit() -> i32 {
+    50
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UnreadRequest {
+    #[serde(default = "default_limit")]
+    pub limit: i32,
+}
+
+impl Default for UnreadRequest {
+    fn default() -> Self {
+        Self {
+            limit: default_limit(),
+        }
+    }
+}
+
+impl From<UnreadArgs> for UnreadRequest {
+    fn from(args: UnreadArgs) -> Self {
+        Self { limit: args.limit }
+    }
+}
+
 pub async fn list_unread<C: TelegramClient>(client: &C, limit: i32) -> Result<Vec<ChatInfo>> {
     client.get_unread_chats(limit).await
+}
+
+pub async fn handle<C: TelegramClient>(client: &C, req: UnreadRequest) -> Result<Vec<ChatInfo>> {
+    list_unread(client, req.limit).await
 }
 
 #[cfg(test)]
@@ -18,5 +49,12 @@ mod tests {
         // Should include John Doe (unread_count: 2) and Family Chat (unread_count: 5)
         assert_eq!(chats.len(), 2);
         assert!(chats.iter().all(|c| c.unread_count > 0));
+    }
+
+    #[tokio::test]
+    async fn handle_uses_request_limit() {
+        let client = MockClient::default();
+        let chats = handle(&client, UnreadRequest { limit: 50 }).await.unwrap();
+        assert_eq!(chats.len(), 2);
     }
 }

--- a/src/commands/whoami.rs
+++ b/src/commands/whoami.rs
@@ -1,9 +1,18 @@
+use serde::{Deserialize, Serialize};
+
 use crate::client::TelegramClient;
 use crate::error::Result;
 use crate::output::UserInfo;
 
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct WhoamiRequest {}
+
 pub async fn whoami<C: TelegramClient>(client: &C) -> Result<UserInfo> {
     client.get_me().await
+}
+
+pub async fn handle<C: TelegramClient>(client: &C, _req: WhoamiRequest) -> Result<UserInfo> {
+    whoami(client).await
 }
 
 #[cfg(test)]
@@ -20,5 +29,12 @@ mod tests {
         assert_eq!(info.last_name, "Doe");
         assert_eq!(info.username, Some("johndoe".to_string()));
         assert_eq!(info.phone, Some("+1234567890".to_string()));
+    }
+
+    #[tokio::test]
+    async fn handle_invokes_whoami() {
+        let client = MockClient::default();
+        let info = handle(&client, WhoamiRequest::default()).await.unwrap();
+        assert_eq!(info.id, 42);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,8 @@ pub mod credentials;
 pub mod error;
 pub mod output;
 pub mod resolve;
+pub mod serve;
+pub mod serve_client;
 
 pub use cli::{Cli, Command};
 pub use client::{TdLibClient, TelegramClient};

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,21 +1,25 @@
 use clap::Parser;
-use std::path::Path;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
 use tg::bot_api;
 use tg::cli::{Cli, Command};
 use tg::client::TdLibClient;
 use tg::commands::{
-    auth_status, chats, download, groups, mark_read, mark_unread, messages, search, send, sync,
-    unread, whoami,
+    auth_status, chats, download, groups, mark_read, mark_unread, messages, search, send, serve,
+    sync, unread, whoami,
 };
 use tg::credentials::{self, ApiCredentials, BotEntry, CredentialsFile};
 use tg::error::{Result, TgError};
 use tg::output::{
-    DownloadStatus, OutputFormat, SendResult, print_chats_table, print_contacts_table, print_error,
-    print_list, print_messages_table, print_output, print_success,
+    ChatInfo, ContactInfo, DownloadReport, DownloadStatus, MessageInfo, OutputFormat, SendResult,
+    UserInfo, print_chats_table, print_contacts_table, print_error, print_list,
+    print_messages_table, print_output, print_success,
 };
 use tg::resolve::{self, Recipient};
+use tg::serve_client;
+use tokio::net::UnixStream;
 
 #[tokio::main]
 async fn main() -> ExitCode {
@@ -33,7 +37,7 @@ async fn main() -> ExitCode {
 async fn run(command: Command, format: OutputFormat) -> Result<()> {
     let data_dir = credentials::tg_data_dir();
 
-    // Handle `tg auth bot` / `tg auth status` separately — no TDLib client needed.
+    // Auth subcommands that don't need TDLib at all.
     if let Command::Auth(ref args) = command {
         match args.subcommand {
             Some(tg::cli::AuthSubcommand::Bot(ref bot_args)) => {
@@ -44,18 +48,39 @@ async fn run(command: Command, format: OutputFormat) -> Result<()> {
                 print_output(format, &status);
                 return Ok(());
             }
-            None => {}
+            None => {
+                // Interactive auth — refuse if `tg serve` is up, since both
+                // want exclusive access to the TDLib on-disk database.
+                if serve_client::is_running().await {
+                    return Err(TgError::Other(
+                        "tg auth: cannot run while `tg serve` is active. Stop the serve process and retry."
+                            .to_string(),
+                    ));
+                }
+            }
         }
     }
 
-    // Handle --as bot sends via HTTP API (may need TDLib for --to resolution).
+    // Bot sends use the HTTP API, never TDLib — bypass the proxy entirely.
     if let Command::Send(ref args) = command
         && args.send_as.is_some()
     {
         return run_bot_send(args, &data_dir, format).await;
     }
 
+    // Serve owns the TDLib client and handles its own lifecycle.
+    if matches!(command, Command::Serve) {
+        let api_credentials = credentials::load_credentials_for_non_auth(&data_dir)?;
+        let client = TdLibClient::new(api_credentials.api_id, api_credentials.api_hash)?;
+        return serve::run(client).await;
+    }
+
+    // Try the warm serve socket first. If unreachable, fall through to the
+    // in-process path so existing usage keeps working with no server up.
     let is_auth = matches!(&command, Command::Auth(a) if a.subcommand.is_none());
+    if !is_auth && let Some(stream) = serve_client::try_connect().await {
+        return route_via_serve(command, stream, format).await;
+    }
 
     let api_credentials = if is_auth {
         match credentials::try_load_credentials_for_auth(&data_dir) {
@@ -108,6 +133,145 @@ async fn run(command: Command, format: OutputFormat) -> Result<()> {
     }
 
     result
+}
+
+/// Forward a command to a running `tg serve` over an already-connected socket
+/// and render the response locally.
+async fn route_via_serve(command: Command, stream: UnixStream, format: OutputFormat) -> Result<()> {
+    match command {
+        Command::Whoami => {
+            let info: UserInfo =
+                serve_client::send_request(stream, "whoami", whoami::WhoamiRequest::default())
+                    .await?;
+            print_output(format, &info);
+        }
+        Command::Chats(args) => {
+            let req = chats::ChatsRequest::from(args);
+            let chats: Vec<ChatInfo> = serve_client::send_request(stream, "chats", req).await?;
+            render_chat_list(format, &chats);
+        }
+        Command::Groups(args) => {
+            let req = groups::GroupsRequest::from(args);
+            let groups: Vec<ChatInfo> = serve_client::send_request(stream, "groups", req).await?;
+            render_chat_list(format, &groups);
+        }
+        Command::Unread(args) => {
+            let req = unread::UnreadRequest::from(args);
+            let unread: Vec<ChatInfo> = serve_client::send_request(stream, "unread", req).await?;
+            render_chat_list(format, &unread);
+        }
+        Command::Search(args) => {
+            let req = search::SearchRequest::from(args);
+            let contacts: Vec<ContactInfo> =
+                serve_client::send_request(stream, "search", req).await?;
+            match format {
+                OutputFormat::Json => print_list(format, &contacts),
+                OutputFormat::Plain => print_contacts_table(&contacts),
+            }
+        }
+        Command::Messages(args) => {
+            let req = messages::MessagesRequest::from(args);
+            let msgs: Vec<MessageInfo> =
+                serve_client::send_request(stream, "messages", req).await?;
+            match format {
+                OutputFormat::Json => print_list(format, &msgs),
+                OutputFormat::Plain => print_messages_table(&msgs),
+            }
+        }
+        Command::Send(args) => {
+            // Bot sends are filtered out before route_via_serve.
+            let req = send::SendRequest::from(args);
+            let result: SendResult = serve_client::send_request(stream, "send", req).await?;
+            print_output(format, &result);
+        }
+        Command::Download(args) => {
+            let mut req = download::DownloadRequest::from(args);
+            // Resolve output_dir relative to the CLIENT's CWD before sending —
+            // the server may have a different working directory.
+            req.output_dir = absolutize(&req.output_dir);
+            let report: DownloadReport =
+                serve_client::send_request(stream, "download", req).await?;
+            print_output(format, &report);
+            match report.status {
+                DownloadStatus::NoDownloadableMedia => {
+                    return Err(TgError::Other(
+                        "Selected message has no downloadable media".to_string(),
+                    ));
+                }
+                DownloadStatus::Failed => {
+                    return Err(TgError::Other("One or more downloads failed".to_string()));
+                }
+                _ => {}
+            }
+        }
+        Command::MarkRead(args) => {
+            let req = mark_read::MarkReadRequest::from(args);
+            let _: serde_json::Value = serve_client::send_request(stream, "mark_read", req).await?;
+            print_success("Chat marked as read");
+        }
+        Command::MarkUnread(args) => {
+            let req = mark_unread::MarkUnreadRequest::from(args);
+            let _: serde_json::Value =
+                serve_client::send_request(stream, "mark_unread", req).await?;
+            print_success("Chat marked as unread");
+        }
+        Command::Sync(args) => {
+            let hwm = read_sync_hwm_from_stdin()?;
+            let req = sync::SyncRequest {
+                hwm,
+                limit: args.limit,
+                reconcile_days: args.reconcile_days,
+            };
+            let results: HashMap<String, sync::SyncResult> =
+                serve_client::send_request(stream, "sync", req).await?;
+            println!("{}", serde_json::to_string_pretty(&results).unwrap());
+            let has_errors = results
+                .values()
+                .any(|r| matches!(r, sync::SyncResult::Error { .. }));
+            if has_errors {
+                return Err(TgError::Other(
+                    "One or more chats failed to sync".to_string(),
+                ));
+            }
+        }
+        Command::Serve | Command::Auth(_) => {
+            unreachable!("Serve and Auth are routed before route_via_serve")
+        }
+    }
+    Ok(())
+}
+
+fn absolutize(path: &Path) -> PathBuf {
+    if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir()
+            .map(|cwd| cwd.join(path))
+            .unwrap_or_else(|_| path.to_path_buf())
+    }
+}
+
+fn render_chat_list(format: OutputFormat, chats: &[ChatInfo]) {
+    match format {
+        OutputFormat::Json => print_list(format, chats),
+        OutputFormat::Plain => print_chats_table(chats),
+    }
+}
+
+fn read_sync_hwm_from_stdin() -> Result<HashMap<String, i64>> {
+    use std::io::Read;
+    let mut buf = String::new();
+    std::io::stdin()
+        .read_to_string(&mut buf)
+        .map_err(|e| TgError::Other(format!("Failed to read stdin: {e}")))?;
+    let parsed: HashMap<String, i64> =
+        serde_json::from_str(&buf).map_err(|e| TgError::Other(format!("Invalid JSON: {e}")))?;
+    for k in parsed.keys() {
+        if k.parse::<i64>().is_err() {
+            return Err(TgError::Other(format!("Invalid chat ID: {k}")));
+        }
+    }
+    Ok(parsed)
 }
 
 async fn run_auth_bot(args: &tg::cli::AuthBotArgs, data_dir: &std::path::Path) -> Result<()> {
@@ -264,28 +428,19 @@ async fn run_command(
         Command::Chats(args) => {
             client.start().await?;
             let chats = chats::list_chats(client, args.limit).await?;
-            match format {
-                OutputFormat::Json => print_list(format, &chats),
-                OutputFormat::Plain => print_chats_table(&chats),
-            }
+            render_chat_list(format, &chats);
         }
 
         Command::Groups(args) => {
             client.start().await?;
             let groups = groups::list_groups(client, args.limit).await?;
-            match format {
-                OutputFormat::Json => print_list(format, &groups),
-                OutputFormat::Plain => print_chats_table(&groups),
-            }
+            render_chat_list(format, &groups);
         }
 
         Command::Unread(args) => {
             client.start().await?;
             let unread = unread::list_unread(client, args.limit).await?;
-            match format {
-                OutputFormat::Json => print_list(format, &unread),
-                OutputFormat::Plain => print_chats_table(&unread),
-            }
+            render_chat_list(format, &unread);
         }
 
         Command::Search(args) => {
@@ -417,7 +572,7 @@ async fn run_command(
                 buf
             };
 
-            let hwm_map = sync::parse_hwm_input(&input).map_err(|e| TgError::Other(e))?;
+            let hwm_map = sync::parse_hwm_input(&input).map_err(TgError::Other)?;
             let results = sync::sync_chats(client, hwm_map, args.limit, args.reconcile_days).await;
 
             let has_errors = results
@@ -432,6 +587,12 @@ async fn run_command(
                     "One or more chats failed to sync".to_string(),
                 ));
             }
+        }
+
+        Command::Serve => {
+            // Serve is handled at the top of `run()` because it owns the
+            // TDLib client and its own shutdown lifecycle.
+            unreachable!("Serve is handled at the top of run()");
         }
     }
 

--- a/src/output.rs
+++ b/src/output.rs
@@ -1,6 +1,6 @@
 use colored::Colorize;
 use comfy_table::{Attribute, Cell, CellAlignment, ContentArrangement, Table};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::env;
 use terminal_size::terminal_size;
 use unicode_width::UnicodeWidthStr;
@@ -57,7 +57,7 @@ pub trait PlainText {
     fn to_plain_text(&self) -> String;
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ChatInfo {
     pub id: i64,
     pub name: String,
@@ -260,7 +260,7 @@ pub fn print_chats_table(chats: &[ChatInfo]) {
     println!("{table}");
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ContactInfo {
     pub id: i64,
     pub name: String,
@@ -385,7 +385,7 @@ pub fn print_messages_table(messages: &[MessageInfo]) {
     println!("{}", messages_table_string(messages));
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum MessageContentDetails {
     Text {
@@ -687,7 +687,7 @@ pub enum MessageContentDetails {
     },
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MessageFileRef {
     pub file_id: i32,
     pub is_primary: bool,
@@ -709,7 +709,7 @@ pub struct MessageFileRef {
     pub is_downloaded: bool,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MessageInfo {
     pub id: i64,
     pub chat_id: i64,
@@ -746,7 +746,7 @@ impl PlainText for MessageInfo {
     }
 }
 
-#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum DownloadStatus {
     Downloaded,
@@ -756,7 +756,7 @@ pub enum DownloadStatus {
     NoDownloadableMedia,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DownloadedFileResult {
     pub file_id: i32,
     pub is_primary: bool,
@@ -777,7 +777,7 @@ pub struct DownloadedFileResult {
     pub note: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DownloadReport {
     pub chat_id: i64,
     pub message_id: i64,
@@ -816,7 +816,7 @@ impl PlainText for DownloadReport {
     }
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UserInfo {
     pub id: i64,
     pub first_name: String,
@@ -846,7 +846,7 @@ impl PlainText for UserInfo {
     }
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SendResult {
     pub message_id: i64,
     pub chat_id: i64,

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -1,0 +1,243 @@
+//! Shared serve-protocol primitives: socket path resolution, request/response
+//! envelopes, and the command dispatcher. Used by both the server
+//! (`commands/serve.rs`) and the client-side proxy (`serve_client.rs`).
+
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+use crate::client::TelegramClient;
+use crate::commands::{
+    chats, download, groups, mark_read, mark_unread, messages, search, send, sync, unread, whoami,
+};
+use crate::credentials::tg_data_dir;
+use crate::error::{Result, TgError};
+
+/// Resolve the Unix socket path for `tg serve`.
+///
+/// - `TG_SERVE_SOCKET=/explicit/path` → use that path verbatim.
+/// - `TG_SERVE_SOCKET=` (set but empty) → return `None` (disabled).
+/// - `XDG_RUNTIME_DIR` set → `$XDG_RUNTIME_DIR/tg.sock`.
+/// - Otherwise → `dirs::data_dir()/tg/serve.sock` (or `tg_data_dir()` fallback).
+pub fn socket_path() -> Option<PathBuf> {
+    match std::env::var_os("TG_SERVE_SOCKET") {
+        Some(v) if v.is_empty() => None,
+        Some(v) => Some(PathBuf::from(v)),
+        None => {
+            if let Some(dir) = std::env::var_os("XDG_RUNTIME_DIR")
+                && !dir.is_empty()
+            {
+                Some(PathBuf::from(dir).join("tg.sock"))
+            } else {
+                Some(tg_data_dir().join("serve.sock"))
+            }
+        }
+    }
+}
+
+/// Incoming request envelope: `{"id": ..., "cmd": ..., "args": ...}`.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct RequestEnvelope {
+    /// Opaque correlation token, echoed back on the matching response.
+    #[serde(default)]
+    pub id: serde_json::Value,
+    pub cmd: String,
+    #[serde(default)]
+    pub args: serde_json::Value,
+}
+
+/// Outgoing response envelope. Either `{"ok": true, "result": ...}` or
+/// `{"ok": false, "error": "..."}`, with `id` always echoed.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ResponseEnvelope {
+    pub id: serde_json::Value,
+    pub ok: bool,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub result: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub error: Option<String>,
+}
+
+impl ResponseEnvelope {
+    pub fn ok(id: serde_json::Value, value: serde_json::Value) -> Self {
+        Self {
+            id,
+            ok: true,
+            result: Some(value),
+            error: None,
+        }
+    }
+
+    pub fn err(id: serde_json::Value, message: impl Into<String>) -> Self {
+        Self {
+            id,
+            ok: false,
+            result: None,
+            error: Some(message.into()),
+        }
+    }
+}
+
+/// Dispatch a single request against a TelegramClient. Always returns a
+/// response (errors are reported in-band).
+pub async fn dispatch<C: TelegramClient>(client: &C, env: RequestEnvelope) -> ResponseEnvelope {
+    let id = env.id.clone();
+    let result: Result<serde_json::Value> = match env.cmd.as_str() {
+        "whoami" => execute(env.args, |r| whoami::handle(client, r)).await,
+        "chats" => execute(env.args, |r| chats::handle(client, r)).await,
+        "groups" => execute(env.args, |r| groups::handle(client, r)).await,
+        "unread" => execute(env.args, |r| unread::handle(client, r)).await,
+        "search" => execute(env.args, |r| search::handle(client, r)).await,
+        "messages" => execute(env.args, |r| messages::handle(client, r)).await,
+        "send" => execute(env.args, |r| send::handle(client, r)).await,
+        "download" => execute(env.args, |r| download::handle(client, r)).await,
+        "mark_read" => execute(env.args, |r| mark_read::handle(client, r)).await,
+        "mark_unread" => execute(env.args, |r| mark_unread::handle(client, r)).await,
+        "sync" => execute(env.args, |r| sync::handle(client, r)).await,
+        "auth" | "auth_bot" | "auth_status" => Err(TgError::Other(
+            "auth is not available over `tg serve`; stop the serve process and run `tg auth` directly"
+                .to_string(),
+        )),
+        other => Err(TgError::Other(format!("unknown command: {other}"))),
+    };
+
+    match result {
+        Ok(v) => ResponseEnvelope::ok(id, v),
+        Err(e) => ResponseEnvelope::err(id, e.to_string()),
+    }
+}
+
+async fn execute<R, T, Fut>(
+    args: serde_json::Value,
+    handler: impl FnOnce(R) -> Fut,
+) -> Result<serde_json::Value>
+where
+    R: serde::de::DeserializeOwned,
+    T: serde::Serialize,
+    Fut: std::future::Future<Output = Result<T>>,
+{
+    // Treat `null` and missing `args` as an empty object so commands whose
+    // fields all have `#[serde(default)]` can be invoked with no args while
+    // commands with required fields still error if those are missing.
+    let args = if args.is_null() {
+        serde_json::Value::Object(serde_json::Map::new())
+    } else {
+        args
+    };
+    let req: R =
+        serde_json::from_value(args).map_err(|e| TgError::Other(format!("invalid args: {e}")))?;
+    let result = handler(req).await?;
+    serde_json::to_value(&result).map_err(|e| TgError::Other(format!("serialization error: {e}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::client::mock::MockClient;
+    use serde_json::json;
+
+    fn req(id: &str, cmd: &str, args: serde_json::Value) -> RequestEnvelope {
+        RequestEnvelope {
+            id: json!(id),
+            cmd: cmd.to_string(),
+            args,
+        }
+    }
+
+    #[tokio::test]
+    async fn dispatch_whoami_returns_user() {
+        let client = MockClient::default();
+        let res = dispatch(&client, req("1", "whoami", serde_json::Value::Null)).await;
+        assert!(res.ok);
+        assert_eq!(res.id, json!("1"));
+        let r = res.result.unwrap();
+        assert_eq!(r["id"], 42);
+        assert_eq!(r["first_name"], "John");
+    }
+
+    #[tokio::test]
+    async fn dispatch_chats_uses_limit_default() {
+        let client = MockClient::default();
+        let res = dispatch(&client, req("2", "chats", json!({}))).await;
+        assert!(res.ok);
+        let arr = res.result.unwrap();
+        assert!(arr.is_array());
+    }
+
+    #[tokio::test]
+    async fn dispatch_unknown_command_returns_error() {
+        let client = MockClient::default();
+        let res = dispatch(&client, req("3", "nope", serde_json::Value::Null)).await;
+        assert!(!res.ok);
+        let err = res.error.unwrap();
+        assert!(err.contains("unknown command"));
+        assert!(err.contains("nope"));
+    }
+
+    #[tokio::test]
+    async fn dispatch_auth_is_refused() {
+        let client = MockClient::default();
+        let res = dispatch(&client, req("4", "auth", serde_json::Value::Null)).await;
+        assert!(!res.ok);
+        assert!(res.error.unwrap().contains("auth is not available"));
+    }
+
+    #[tokio::test]
+    async fn dispatch_handler_error_returns_in_band() {
+        let client = MockClient::default();
+        // mark_read without id or name should fail in the handler
+        let res = dispatch(&client, req("5", "mark_read", json!({}))).await;
+        assert!(!res.ok);
+        assert!(res.error.unwrap().contains("either `id` or `name`"));
+    }
+
+    #[tokio::test]
+    async fn dispatch_invalid_args_returns_error_keeping_id() {
+        let client = MockClient::default();
+        let res = dispatch(
+            &client,
+            req("6", "messages", json!({"limit": "not-a-number"})),
+        )
+        .await;
+        assert!(!res.ok);
+        assert_eq!(res.id, json!("6"));
+        assert!(res.error.unwrap().contains("invalid args"));
+    }
+
+    #[tokio::test]
+    async fn dispatch_send_returns_result_shape() {
+        let client = MockClient::default();
+        let res = dispatch(
+            &client,
+            req("7", "send", json!({"message": "hi", "id": 42})),
+        )
+        .await;
+        assert!(res.ok);
+        let r = res.result.unwrap();
+        assert_eq!(r["chat_id"], 42);
+    }
+
+    // Env-var-mutating tests are gathered into one to avoid cross-test races on
+    // the shared process environment.
+    #[test]
+    fn socket_path_respects_env_variants() {
+        let prev = std::env::var_os("TG_SERVE_SOCKET");
+
+        // Explicit path
+        unsafe { std::env::set_var("TG_SERVE_SOCKET", "/tmp/tg-explicit.sock") };
+        assert_eq!(
+            socket_path().unwrap(),
+            PathBuf::from("/tmp/tg-explicit.sock")
+        );
+
+        // Empty means disabled
+        unsafe { std::env::set_var("TG_SERVE_SOCKET", "") };
+        assert!(socket_path().is_none());
+
+        // Restore prior state
+        match prev {
+            Some(v) => unsafe { std::env::set_var("TG_SERVE_SOCKET", v) },
+            None => unsafe { std::env::remove_var("TG_SERVE_SOCKET") },
+        }
+    }
+}

--- a/src/serve_client.rs
+++ b/src/serve_client.rs
@@ -1,0 +1,77 @@
+//! Client-side proxy: try to forward a request to a running `tg serve`, fall
+//! back to in-process TDLib when no server is reachable.
+
+use serde::Serialize;
+use serde::de::DeserializeOwned;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::UnixStream;
+
+use crate::error::{Result, TgError};
+use crate::serve::{self, RequestEnvelope, ResponseEnvelope};
+
+/// Maximum time the client waits to establish a socket connection. Connect is
+/// a kernel-level handshake; this is not a request timeout.
+const CONNECT_TIMEOUT_MS: u64 = 500;
+
+/// Try to connect to a running `tg serve`. Returns `None` if the socket is
+/// missing, the env var disables it, or the connect attempt fails.
+pub async fn try_connect() -> Option<UnixStream> {
+    let path = serve::socket_path()?;
+    if !path.exists() {
+        return None;
+    }
+    match tokio::time::timeout(
+        std::time::Duration::from_millis(CONNECT_TIMEOUT_MS),
+        UnixStream::connect(&path),
+    )
+    .await
+    {
+        Ok(Ok(stream)) => Some(stream),
+        _ => None,
+    }
+}
+
+/// Returns `true` when a `tg serve` is reachable on its socket.
+pub async fn is_running() -> bool {
+    try_connect().await.is_some()
+}
+
+/// Send a single request over an established stream and parse the response
+/// into `T`. The stream is consumed: this is one request per connection.
+pub async fn send_request<A: Serialize, T: DeserializeOwned>(
+    stream: UnixStream,
+    cmd: &str,
+    args: A,
+) -> Result<T> {
+    let env = RequestEnvelope {
+        id: serde_json::Value::String("1".to_string()),
+        cmd: cmd.to_string(),
+        args: serde_json::to_value(args)
+            .map_err(|e| TgError::Other(format!("serialize request: {e}")))?,
+    };
+
+    let (read, mut write) = stream.into_split();
+
+    let mut line = serde_json::to_string(&env)?;
+    line.push('\n');
+    write.write_all(line.as_bytes()).await?;
+    write.flush().await?;
+
+    let mut lines = BufReader::new(read).lines();
+    let response_line = lines.next_line().await?.ok_or_else(|| {
+        TgError::Other("tg serve: connection closed without response".to_string())
+    })?;
+
+    let response: ResponseEnvelope = serde_json::from_str(&response_line)
+        .map_err(|e| TgError::Other(format!("tg serve: invalid response: {e}")))?;
+
+    if response.ok {
+        let value = response.result.unwrap_or(serde_json::Value::Null);
+        serde_json::from_value(value)
+            .map_err(|e| TgError::Other(format!("tg serve: result parse error: {e}")))
+    } else {
+        Err(TgError::Other(response.error.unwrap_or_else(|| {
+            "tg serve: unknown server error".to_string()
+        })))
+    }
+}

--- a/tests/serve_integration.rs
+++ b/tests/serve_integration.rs
@@ -1,0 +1,259 @@
+//! Integration tests for the serve protocol: real sockets, real framing,
+//! using a stub echo server in place of TDLib so the test suite stays
+//! hermetic.
+//!
+//! The dispatch logic itself is covered by unit tests in `src/serve.rs`.
+//! These tests focus on the wire layer: socket binding, stale-socket
+//! cleanup, already-running detection, and the per-request round-trip
+//! performed by `serve_client::send_request`.
+
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+use tempfile::TempDir;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::{UnixListener, UnixStream};
+
+use tg::commands::serve::prepare_socket_path;
+use tg::serve::{RequestEnvelope, ResponseEnvelope};
+use tg::serve_client;
+
+fn sock_path(dir: &TempDir, name: &str) -> PathBuf {
+    dir.path().join(name)
+}
+
+/// Minimal NDJSON server that handles one connection, dispatches each
+/// request via the provided closure, and exits when the peer closes.
+async fn stub_server<F>(path: &Path, handler: F)
+where
+    F: Fn(&RequestEnvelope) -> ResponseEnvelope + Send + Sync + 'static,
+{
+    let listener = UnixListener::bind(path).unwrap();
+    let (stream, _) = listener.accept().await.unwrap();
+    let (read, mut write) = stream.into_split();
+    let mut lines = BufReader::new(read).lines();
+    while let Some(line) = lines.next_line().await.unwrap() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let req: RequestEnvelope = serde_json::from_str(&line).unwrap();
+        let resp = handler(&req);
+        let mut out = serde_json::to_string(&resp).unwrap();
+        out.push('\n');
+        write.write_all(out.as_bytes()).await.unwrap();
+        write.flush().await.unwrap();
+    }
+}
+
+#[tokio::test]
+async fn prepare_socket_path_removes_stale_file() {
+    let dir = TempDir::new().unwrap();
+    let path = sock_path(&dir, "stale.sock");
+    std::fs::write(&path, b"garbage").unwrap();
+    assert!(path.exists());
+    prepare_socket_path(&path).await.unwrap();
+    assert!(
+        !path.exists(),
+        "stale file at {path:?} should be unlinked",
+        path = path
+    );
+}
+
+#[tokio::test]
+async fn prepare_socket_path_detects_running_server() {
+    let dir = TempDir::new().unwrap();
+    let path = sock_path(&dir, "alive.sock");
+    // A real listener at the path simulates an already-running server.
+    let _listener = UnixListener::bind(&path).unwrap();
+    let err = prepare_socket_path(&path).await.unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("already running"),
+        "expected 'already running' error, got: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn prepare_socket_path_creates_parent_dir() {
+    let dir = TempDir::new().unwrap();
+    let nested = dir.path().join("does/not/exist/yet/tg.sock");
+    prepare_socket_path(&nested).await.unwrap();
+    assert!(nested.parent().unwrap().exists());
+}
+
+#[tokio::test]
+async fn wire_round_trip_carries_id_and_result() {
+    let dir = TempDir::new().unwrap();
+    let path = sock_path(&dir, "echo.sock");
+
+    let server_path = path.clone();
+    let server = tokio::spawn(async move {
+        stub_server(&server_path, |req| {
+            ResponseEnvelope::ok(req.id.clone(), serde_json::json!({"echoed_cmd": req.cmd}))
+        })
+        .await;
+    });
+
+    // Give the listener a moment to bind.
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    let stream = UnixStream::connect(&path).await.unwrap();
+
+    #[derive(Deserialize, Debug)]
+    struct Echo {
+        echoed_cmd: String,
+    }
+
+    let result: Echo = serve_client::send_request(stream, "whoami", serde_json::json!({}))
+        .await
+        .unwrap();
+    assert_eq!(result.echoed_cmd, "whoami");
+
+    server.await.unwrap();
+}
+
+#[tokio::test]
+async fn wire_surfaces_server_side_error_as_tg_error() {
+    let dir = TempDir::new().unwrap();
+    let path = sock_path(&dir, "err.sock");
+
+    let server_path = path.clone();
+    let server = tokio::spawn(async move {
+        stub_server(&server_path, |req| {
+            ResponseEnvelope::err(req.id.clone(), "boom")
+        })
+        .await;
+    });
+
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    let stream = UnixStream::connect(&path).await.unwrap();
+    let err =
+        serve_client::send_request::<_, serde_json::Value>(stream, "whoami", serde_json::json!({}))
+            .await
+            .unwrap_err();
+    assert!(err.to_string().contains("boom"));
+
+    server.await.unwrap();
+}
+
+#[tokio::test]
+async fn pipelined_requests_preserve_arrival_order() {
+    let dir = TempDir::new().unwrap();
+    let path = sock_path(&dir, "pipe.sock");
+
+    let server_path = path.clone();
+    let server = tokio::spawn(async move {
+        stub_server(&server_path, |req| {
+            ResponseEnvelope::ok(req.id.clone(), serde_json::json!({"cmd": req.cmd}))
+        })
+        .await;
+    });
+
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    let stream = UnixStream::connect(&path).await.unwrap();
+    let (read, mut write) = stream.into_split();
+    let mut lines = BufReader::new(read).lines();
+
+    for i in 0..5 {
+        let req = RequestEnvelope {
+            id: serde_json::json!(i),
+            cmd: format!("cmd-{i}"),
+            args: serde_json::Value::Null,
+        };
+        let mut line = serde_json::to_string(&req).unwrap();
+        line.push('\n');
+        write.write_all(line.as_bytes()).await.unwrap();
+    }
+    write.flush().await.unwrap();
+    drop(write); // signals EOF to server
+
+    let mut ids = Vec::new();
+    for _ in 0..5 {
+        let line = lines.next_line().await.unwrap().unwrap();
+        let resp: ResponseEnvelope = serde_json::from_str(&line).unwrap();
+        ids.push(resp.id);
+    }
+    assert_eq!(
+        ids,
+        (0..5).map(|i| serde_json::json!(i)).collect::<Vec<_>>(),
+        "responses must arrive in request order"
+    );
+
+    server.await.unwrap();
+}
+
+#[tokio::test]
+async fn parallel_connections_each_get_their_own_response() {
+    let dir = TempDir::new().unwrap();
+    let path = sock_path(&dir, "par.sock");
+
+    let server_path = path.clone();
+    let server = tokio::spawn(async move {
+        let listener = UnixListener::bind(&server_path).unwrap();
+        for _ in 0..3 {
+            let (stream, _) = listener.accept().await.unwrap();
+            tokio::spawn(async move {
+                let (read, mut write) = stream.into_split();
+                let mut lines = BufReader::new(read).lines();
+                if let Some(line) = lines.next_line().await.unwrap() {
+                    let req: RequestEnvelope = serde_json::from_str(&line).unwrap();
+                    let resp =
+                        ResponseEnvelope::ok(req.id.clone(), serde_json::json!({"cmd": req.cmd}));
+                    let mut out = serde_json::to_string(&resp).unwrap();
+                    out.push('\n');
+                    write.write_all(out.as_bytes()).await.unwrap();
+                    write.flush().await.unwrap();
+                }
+            });
+        }
+    });
+
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    #[derive(Deserialize)]
+    struct Resp {
+        cmd: String,
+    }
+
+    let mut handles = Vec::new();
+    for i in 0..3 {
+        let p = path.clone();
+        handles.push(tokio::spawn(async move {
+            let stream = UnixStream::connect(&p).await.unwrap();
+            let r: Resp =
+                serve_client::send_request(stream, &format!("conn-{i}"), serde_json::json!({}))
+                    .await
+                    .unwrap();
+            r.cmd
+        }));
+    }
+
+    let mut got: Vec<String> = Vec::new();
+    for h in handles {
+        got.push(h.await.unwrap());
+    }
+    got.sort();
+    assert_eq!(
+        got,
+        vec![
+            "conn-0".to_string(),
+            "conn-1".to_string(),
+            "conn-2".to_string()
+        ]
+    );
+
+    server.await.unwrap();
+}
+
+#[tokio::test]
+async fn try_connect_returns_none_when_path_missing() {
+    // We don't manipulate TG_SERVE_SOCKET here (would race with other tests).
+    // Instead, hit UnixStream::connect directly with a known-missing path —
+    // that's the underlying check try_connect performs.
+    let dir = TempDir::new().unwrap();
+    let missing = sock_path(&dir, "absent.sock");
+    let result = UnixStream::connect(&missing).await;
+    assert!(result.is_err(), "connecting to missing socket should fail");
+}

--- a/tests/serve_integration.rs
+++ b/tests/serve_integration.rs
@@ -46,16 +46,37 @@ where
 }
 
 #[tokio::test]
-async fn prepare_socket_path_removes_stale_file() {
+async fn prepare_socket_path_removes_real_stale_socket() {
     let dir = TempDir::new().unwrap();
     let path = sock_path(&dir, "stale.sock");
-    std::fs::write(&path, b"garbage").unwrap();
+    // Create a real Unix socket then drop the listener — the path remains
+    // as a socket file with no listener, so connect() returns ECONNREFUSED.
+    let listener = UnixListener::bind(&path).unwrap();
+    drop(listener);
     assert!(path.exists());
     prepare_socket_path(&path).await.unwrap();
     assert!(
         !path.exists(),
-        "stale file at {path:?} should be unlinked",
+        "real stale socket at {path:?} should be unlinked",
         path = path
+    );
+}
+
+#[tokio::test]
+async fn prepare_socket_path_refuses_when_path_is_plain_file() {
+    let dir = TempDir::new().unwrap();
+    let path = sock_path(&dir, "not-a-socket");
+    std::fs::write(&path, b"garbage").unwrap();
+    let err = prepare_socket_path(&path).await.unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("not a stale socket") || msg.contains("refusing to start"),
+        "expected refusal-to-start error for non-socket path, got: {msg}"
+    );
+    // The plain file must NOT be removed — that would be a destructive surprise.
+    assert!(
+        path.exists(),
+        "non-socket file at {path:?} must not be removed"
     );
 }
 

--- a/tests/serve_integration.rs
+++ b/tests/serve_integration.rs
@@ -70,7 +70,7 @@ async fn prepare_socket_path_refuses_when_path_is_plain_file() {
     let err = prepare_socket_path(&path).await.unwrap_err();
     let msg = err.to_string();
     assert!(
-        msg.contains("not a stale socket") || msg.contains("refusing to start"),
+        msg.contains("not a socket") || msg.contains("refusing to start"),
         "expected refusal-to-start error for non-socket path, got: {msg}"
     );
     // The plain file must NOT be removed — that would be a destructive surprise.


### PR DESCRIPTION
## Summary

- `tg serve` runs a background process that keeps one TDLib client warm and exposes it over a Unix socket.
- Every other `tg <cmd>` auto-detects the socket and forwards its request, falling back to in-process TDLib when no server is up. Existing usage works unchanged.
- Per-command handler factoring: each `commands/<name>.rs` exposes a `handle(client, req)` plus a `*Request` struct shared between the dispatcher and the in-process path.

## Wire protocol

Newline-delimited JSON over a Unix socket. One request per line, one response per line, in arrival order.

```
{"id": "<opaque>", "cmd": "<command>", "args": { ... }}
{"id": "<echoed>", "ok": true, "result": <value>}
{"id": "<echoed>", "ok": false, "error": "<message>"}
```

## Socket location

`TG_SERVE_SOCKET` env var → `\$XDG_RUNTIME_DIR/tg.sock` → `\$DATA_DIR/tg/serve.sock`. 0600 perms.

## Operational notes

- `tg auth` refuses to run when serve is up with a clear stop-serve message.
- Bot sends (`--as`) and `tg auth status` never touch the socket.
- `tg download --output-dir` resolves to absolute on the client side so relative paths still mean what the user expects.

## Test plan

- [x] 242 unit tests pass (`cargo test --lib`)
- [x] 8 integration tests pass (`cargo test --test serve_integration`)
- [x] `cargo build` clean
- [ ] CI green
- [ ] Manual smoke test against a real `tg serve` after merge

Spec: `docs/superpowers/specs/2026-05-22-serve-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)